### PR TITLE
Example with rmf_demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
 # Free Fleet ROS2
+
+## Contents
+
+- **[About](#About)**
+- **[Installation Instructions](#installation-instructions)**
+  - [Prerequisites](#prerequisites)
+- **[Examples](#examples)**
+</br>
+</br>
+
+## About
+
+Implementation of a Fleet Adapter to integrate [Free Fleet (an upcoming version)](https://github.com/open-rmf/free_fleet/tree/develop) clients with RMF [demos](https://github.com/open-rmf/rmf_demos).
+
+</br>
+</br>
+
+## Installation Instructions
+
+### Prerequisites
+
+* [Ubuntu 20.04 LTS](https://releases.ubuntu.com/20.04/)
+* [ROS2 - Galactic](https://docs.ros.org/en/galactic/index.html)
+* [RMF demos](https://github.com/open-rmf/rmf_demos)
+* [Free Fleet - develop branch](https://github.com/open-rmf/free_fleet/tree/develop)
+
+</br>
+
+### Installation
+Assuming free_fleet and fleet_fleet_ros2 are to be located in your home directory.
+
+#### Free Fleet (develop)
+
+```
+cd ~
+git clone https://github.com/open-rmf/free_fleet.git -b develop
+source /opt/ros/galactic/setup.bash
+source ~/rmf_ws/install/setup.bash
+cd ~/free_fleet
+# free_fleet dependencies
+colcon build
+```
+
+#### Free Fleet ROS2 Implementation
+```bash
+cd ~
+git clone https://github.com/open-rmf/free_fleet_ros2.git -b develop
+source /opt/ros/galactic/setup.bash
+source ~/rmf_ws/install/setup.bash # requires rmf_fleet_msgs and rmf_task_msgs
+source ~/free_fleet/install/setup.bash
+colcon build
+```
+### Examples
+
+To get the demos to use the free_fleet_ros2 adapter instead, modify this launch file:
+Edit ~/rmf_ws/src/rmf/rmf_ros2/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+Comment out lines 43-46
+```xml
+  <!-- <node pkg="rmf_fleet_adapter"
+        exec="$(var control_type)"
+        name="$(var fleet_name)_fleet_adapter"
+        output="both"> -->
+  <node pkg="free_fleet_ros2_adapter"
+        exec="adapter"
+        name="free_fleet_ros2_adapter"
+        output="both">
+```
+
+Rebuild to use the updated launch file:
+`cd ~/rmf_ws; colcon build --packages-select rmf_fleet_adapter`
+
+Open one terminal for the demo+adapters and one for the clients.
+In each:
+```
+source /opt/ros/galactic/setup.bash
+source ~/rmf_ws/install/setup.bash
+source ~/free_fleet_ros2/install/setup.bash
+
+```
+#### Launch demo
+```
+ros2 launch rmf_demos_gz hotel.launch.xml
+```
+#### Launch clients
+The demo should be running before the clients are started.
+```
+ros2 launch free_fleet_ros2_examples hotel_clients.launch.xml
+```
+
+### To do
+- During Cleaning and other tasks which are performed while docking, visualization will not work correctly.
+- Support new speed limit in Location.
+- Complete testing of opening and closing of lanes.
+- Better approach to launch files and address upcoming changes to `rmf_demos` launch and config files.
+- Launch files for remaining demo worlds.

--- a/adapter/CMakeLists.txt
+++ b/adapter/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.7.0)
+project(free_fleet_ros2_adapter)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+if(NOT CMAKE_BUILD_TYPE)
+  # Use the Release build type by default if the user has not specified one
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+find_package(ament_cmake REQUIRED)
+include(GNUInstallDirs)
+
+set(dep_pkgs
+  rclcpp
+  rmf_fleet_msgs
+  rmf_task_msgs
+  rmf_traffic
+  rmf_traffic_ros2
+  rmf_fleet_adapter
+  free_fleet
+  free_fleet_cyclonedds
+  CycloneDDS
+)
+foreach(pkg ${dep_pkgs})
+  find_package(${pkg} REQUIRED)
+endforeach()
+
+# -----------------------------------------------------------------------------
+add_executable(adapter 
+  src/main.cpp
+)
+
+target_link_libraries(adapter
+  PRIVATE
+    free_fleet::free_fleet
+    free_fleet_cyclonedds::free_fleet_cyclonedds
+    rmf_fleet_adapter::rmf_fleet_adapter
+    rmf_traffic::rmf_traffic
+    ${rclcpp_LIBRARIES}
+    ${rmf_fleet_msgs_LIBRARIES}
+    ${rmf_task_msgs_LIBRARIES}
+    CycloneDDS::ddsc
+)
+target_include_directories(adapter
+  PRIVATE
+    ${rmf_fleet_msgs_INCLUDE_DIRS}
+    ${rmf_task_msgs_INCLUDE_DIRS}
+)
+
+install(TARGETS
+  adapter
+  DESTINATION lib/${PROJECT_NAME}
+)
+ament_package()

--- a/adapter/package.xml
+++ b/adapter/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>free_fleet_ros2_adapter</name>
+  <version>1.1.0</version>
+  <description>Free fleet ROS 2 implementations</description>
+  <maintainer email="aaron@openrobotics.org">Aaron</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>rmf_utils</depend>
+  <depend>rmf_traffic</depend>
+  <depend>rmf_traffic_ros2</depend>
+  <depend>rmf_fleet_adapter</depend>
+
+  <depend>free_fleet</depend>
+  <depend>free_fleet_cyclonedds</depend>
+
+  <build_depend>eigen</build_depend>
+
+  <test_depend>ament_cmake_catch2</test_depend>
+  <test_depend>rmf_cmake_uncrustify</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/adapter/src/load_param.cpp
+++ b/adapter/src/load_param.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "load_param.hpp"
+
+#include <rmf_traffic/geometry/Circle.hpp>
+
+namespace rmf_fleet_adapter {
+
+//==============================================================================
+std::chrono::nanoseconds get_parameter_or_default_time(
+  rclcpp::Node& node,
+  const std::string& param_name,
+  const double default_value)
+{
+  const double value =
+    get_parameter_or_default(node, param_name, default_value);
+
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+    std::chrono::duration<double, std::ratio<1>>(value));
+}
+
+//==============================================================================
+std::string get_fleet_name_parameter(rclcpp::Node& node)
+{
+  std::string fleet_name = node.declare_parameter("fleet_name", std::string());
+  if (fleet_name.empty())
+  {
+    RCLCPP_ERROR(
+      node.get_logger(),
+      "The fleet_name parameter must be specified!");
+    throw std::runtime_error("fleet_name parameter is missing");
+  }
+
+  return fleet_name;
+}
+
+//==============================================================================
+rmf_traffic::agv::VehicleTraits get_traits_or_default(rclcpp::Node& node,
+  const double default_v_nom, const double default_w_nom,
+  const double default_a_nom, const double default_alpha_nom,
+  const double default_r_f, const double default_r_v)
+{
+  const double v_nom =
+    get_parameter_or_default(node, "linear_velocity", default_v_nom);
+  const double w_nom =
+    get_parameter_or_default(node, "angular_velocity", default_w_nom);
+  const double a_nom =
+    get_parameter_or_default(node, "linear_acceleration", default_a_nom);
+  const double b_nom =
+    get_parameter_or_default(node, "angular_acceleration", default_alpha_nom);
+  const double r_f =
+    get_parameter_or_default(node, "footprint_radius", default_r_f);
+  const double r_v =
+    get_parameter_or_default(node, "vicinity_radius", default_r_v);
+  const bool reversible =
+    get_parameter_or_default(node, "reversible", true);
+
+  if (!reversible)
+    std::cout << " ===== We have an irreversible robot" << std::endl;
+
+  auto traits = rmf_traffic::agv::VehicleTraits{
+    {v_nom, a_nom},
+    {w_nom, b_nom},
+    rmf_traffic::Profile{
+      rmf_traffic::geometry::make_final_convex<
+        rmf_traffic::geometry::Circle>(r_f),
+      rmf_traffic::geometry::make_final_convex<
+        rmf_traffic::geometry::Circle>(r_v)
+    }
+  };
+
+  traits.get_differential()->set_reversible(reversible);
+  return traits;
+}
+
+
+//==============================================================================
+std::optional<rmf_battery::agv::BatterySystem> get_battery_system(
+  rclcpp::Node& node,
+  const double default_voltage,
+  const double default_capacity,
+  const double default_charging_current)
+{
+  const double voltage =
+    get_parameter_or_default(node, "battery_voltage", default_voltage);
+  const double capacity =
+    get_parameter_or_default(node, "battery_capacity", default_capacity);
+  const double charging_current =
+    get_parameter_or_default(
+    node, "battery_charging_current", default_charging_current);
+
+  auto battery_system = rmf_battery::agv::BatterySystem::make(
+    voltage, capacity, charging_current);
+
+  return battery_system;
+}
+
+//==============================================================================
+std::optional<rmf_battery::agv::MechanicalSystem> get_mechanical_system(
+  rclcpp::Node& node,
+  const double default_mass,
+  const double default_moment,
+  const double default_friction)
+{
+  const double mass =
+    get_parameter_or_default(node, "mass", default_mass);
+  const double moment_of_inertia =
+    get_parameter_or_default(node, "inertia", default_moment);
+  const double friction =
+    get_parameter_or_default(node, "friction_coefficient", default_friction);
+
+  auto mechanical_system = rmf_battery::agv::MechanicalSystem::make(
+    mass, moment_of_inertia, friction);
+
+  return mechanical_system;
+}
+
+} // namespace rmf_fleet_adapter

--- a/adapter/src/load_param.hpp
+++ b/adapter/src/load_param.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__LOAD_PARAM_HPP
+#define SRC__RMF_FLEET_ADAPTER__LOAD_PARAM_HPP
+
+#include <rmf_traffic/agv/VehicleTraits.hpp>
+
+#include <rmf_battery/agv/BatterySystem.hpp>
+#include <rmf_battery/agv/MechanicalSystem.hpp>
+
+#include <rclcpp/node.hpp>
+
+#include <chrono>
+#include <string>
+#include <optional>
+
+namespace rmf_fleet_adapter {
+
+//==============================================================================
+template<typename T>
+T get_parameter_or_default(
+  rclcpp::Node& node,
+  const std::string& param_name,
+  const T& default_value)
+{
+  // TODO(MXG): Consider a way to automatically make a callback that will update
+  // a target variable when the parameter value gets changed.
+
+  const T value = node.declare_parameter(param_name, default_value);
+  RCLCPP_INFO(
+    node.get_logger(),
+    "Parameter [%s] set to: %s",
+    param_name.c_str(),
+    std::to_string(value).c_str());
+  return value;
+}
+
+//==============================================================================
+std::string get_fleet_name_parameter(rclcpp::Node& node);
+
+//==============================================================================
+std::chrono::nanoseconds get_parameter_or_default_time(
+  rclcpp::Node& node,
+  const std::string& param_name,
+  const double default_value);
+
+//==============================================================================
+rmf_traffic::agv::VehicleTraits get_traits_or_default(
+  rclcpp::Node& node,
+  const double default_v_nom, const double default_w_nom,
+  const double default_a_nom, const double default_alpha_nom,
+  const double default_r_f, const double default_r_v);
+
+//==============================================================================
+std::optional<rmf_battery::agv::BatterySystem> get_battery_system(
+  rclcpp::Node& node,
+  const double default_voltage,
+  const double default_capacity,
+  const double default_charging_current);
+
+std::optional<rmf_battery::agv::MechanicalSystem> get_mechanical_system(
+  rclcpp::Node& node,
+  const double default_mass,
+  const double default_inertia,
+  const double default_friction);
+
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__LOAD_PARAM_HPP

--- a/adapter/src/main.cpp
+++ b/adapter/src/main.cpp
@@ -1,0 +1,1194 @@
+#include <iostream>
+
+#include <rclcpp/rclcpp.hpp>
+
+// Public rmf_fleet_adapter API headers
+#include <rmf_fleet_adapter/agv/Adapter.hpp>
+#include <rmf_fleet_adapter/agv/parse_graph.hpp>
+
+// Standard topic names for communicating with fleet drivers
+#include <rmf_fleet_adapter/StandardNames.hpp>
+
+// Fleet driver state/command messages
+#include <rmf_fleet_msgs/msg/fleet_state.hpp>
+#include <rmf_fleet_msgs/msg/path_request.hpp>
+#include <rmf_fleet_msgs/msg/mode_request.hpp>
+#include <rmf_fleet_msgs/srv/lift_clearance.hpp>
+#include <rmf_fleet_msgs/msg/lane_request.hpp>
+#include <rmf_fleet_msgs/msg/closed_lanes.hpp>
+
+// RMF Task messages
+#include <rmf_task_msgs/msg/task_type.hpp>
+#include <rmf_task_msgs/msg/task_profile.hpp>
+
+// ROS2 utilities for rmf_traffic
+#include <rmf_traffic_ros2/Time.hpp>
+
+// Public rmf_task API headers
+#include <rmf_task/requests/ChargeBatteryFactory.hpp>
+#include <rmf_task/requests/ParkRobotFactory.hpp>
+
+// Public rmf_traffic API headers
+#include <rmf_traffic/agv/Interpolate.hpp>
+#include <rmf_traffic/Route.hpp>
+
+#include <rmf_battery/agv/SimpleMotionPowerSink.hpp>
+#include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
+
+#include <free_fleet/Executor.hpp>
+#include <free_fleet/Types.hpp>
+#include <free_fleet/manager/Manager.hpp>
+#include <free_fleet/manager/SimpleCoordinateTransformer.hpp>
+
+#include <free_fleet_cyclonedds/ServerDDSMiddleware.hpp>
+
+#include "load_param.hpp"
+
+//==============================================================================
+rmf_fleet_adapter::agv::RobotUpdateHandle::Unstable::Decision
+convert_decision(uint32_t decision)
+{
+  using namespace rmf_fleet_adapter::agv;
+  switch (decision)
+  {
+    case rmf_fleet_msgs::srv::LiftClearance::Response::DECISION_CLEAR:
+      return RobotUpdateHandle::Unstable::Decision::Clear;
+    case rmf_fleet_msgs::srv::LiftClearance::Response::DECISION_CROWDED:
+      return RobotUpdateHandle::Unstable::Decision::Crowded;
+  }
+
+  std::cerr << "Received undefined value for lift clearance service: "
+            << decision << std::endl;
+  return RobotUpdateHandle::Unstable::Decision::Undefined;
+}
+
+//==============================================================================
+struct DistanceFromGraph
+{
+  double value;
+  std::size_t index;
+
+  enum Type
+  {
+    Waypoint = 0,
+    Lane
+  };
+  Type type;
+};
+
+//==============================================================================
+std::optional<DistanceFromGraph> distance_from_graph(
+  const rmf_fleet_msgs::msg::Location& l,
+  const rmf_traffic::agv::Graph& graph)
+{
+  std::optional<DistanceFromGraph> output;
+  const Eigen::Vector2d p = {l.x, l.y};
+  const std::string& map = l.level_name;
+
+  for (std::size_t i = 0; i < graph.num_waypoints(); ++i)
+  {
+    const auto& wp = graph.get_waypoint(i);
+    if (wp.get_map_name() != map)
+      continue;
+
+    const double dist = (wp.get_location() - p).norm();
+    if (!output.has_value() || (dist < output->value))
+    {
+      output = DistanceFromGraph{dist, i, DistanceFromGraph::Waypoint};
+    }
+  }
+
+  for (std::size_t i = 0; i < graph.num_lanes(); ++i)
+  {
+    const auto& lane = graph.get_lane(i);
+    const auto& wp0 = graph.get_waypoint(lane.entry().waypoint_index());
+    const auto& wp1 = graph.get_waypoint(lane.exit().waypoint_index());
+
+    if (map != wp0.get_map_name() && map != wp1.get_map_name())
+      continue;
+
+    const Eigen::Vector2d p0 = wp0.get_location();
+    const Eigen::Vector2d p1 = wp1.get_location();
+
+    const Eigen::Vector2d dp = p - p0;
+    const Eigen::Vector2d dp1 = p1 - p0;
+
+    const double lane_length = dp1.norm();
+    if (lane_length < 1e-8)
+      continue;
+
+    const double u = dp.dot(dp1)/lane_length;
+    if (u < 0 || lane_length < u)
+      continue;
+
+    const double dist = (dp - u*dp1/lane_length).norm();
+    if (!output.has_value() || (dist < output->value))
+    {
+      output = DistanceFromGraph{dist, i, DistanceFromGraph::Lane};
+    }
+  }
+
+  return output;
+}
+
+struct TravelInfo
+{
+  using ArrivalEstimator =
+    rmf_fleet_adapter::agv::RobotCommandHandle::ArrivalEstimator;
+  using RequestCompleted =
+    rmf_fleet_adapter::agv::RobotCommandHandle::RequestCompleted;
+
+  std::vector<rmf_traffic::agv::Plan::Waypoint> waypoints;
+  ArrivalEstimator next_arrival_estimator;
+  RequestCompleted path_finished_callback;
+  rmf_fleet_adapter::agv::RobotUpdateHandlePtr updater;
+  std::shared_ptr<const rmf_traffic::agv::Graph> graph;
+  std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits;
+
+  std::string fleet_name;
+  std::string robot_name;
+
+  std::optional<std::size_t> target_plan_index = std::nullopt;
+};
+
+//==============================================================================
+class FleetDriverRobotCommandHandle
+  : public rmf_fleet_adapter::agv::RobotCommandHandle
+{
+public:
+
+  using PathRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::PathRequest>::SharedPtr;
+
+  using ModeRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr;
+
+  FleetDriverRobotCommandHandle(
+    rclcpp::Node& node,
+    std::string fleet_name,
+    std::string robot_name,
+    std::shared_ptr<const rmf_traffic::agv::Graph> graph,
+    std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
+    PathRequestPub path_request_pub,
+    ModeRequestPub mode_request_pub,
+    free_fleet::Manager& manager)
+  : _node(&node),
+    _path_request_pub(std::move(path_request_pub)),
+    _mode_request_pub(std::move(mode_request_pub)),
+    _manager(manager)
+  {
+    _travel_info.graph = std::move(graph);
+    _travel_info.traits = std::move(traits);
+    _travel_info.fleet_name = std::move(fleet_name);
+    _travel_info.robot_name = std::move(robot_name);
+  }
+
+  void follow_new_path(
+    const std::vector<rmf_traffic::agv::Plan::Waypoint>& waypoints,
+    ArrivalEstimator next_arrival_estimator,
+    RequestCompleted path_finished_callback) final
+  {
+    auto lock = _lock();
+    _clear_last_command();
+
+    _travel_info.target_plan_index = std::nullopt;
+    _travel_info.waypoints = waypoints;
+    _travel_info.next_arrival_estimator = std::move(next_arrival_estimator);
+    _travel_info.path_finished_callback = std::move(path_finished_callback);
+    _interrupted = false;
+
+    std::vector<free_fleet::Manager::NavigationPoint> path;
+
+    for (const auto& wp : waypoints)
+    {
+      rmf_fleet_msgs::msg::Location location;
+      const Eigen::Vector3d p = wp.position();
+      location.t = rmf_traffic_ros2::convert(wp.time());
+      location.x = p.x();
+      location.y = p.y();
+      location.yaw = p.z();
+
+      // Note: if the waypoint is not on a graph index, then we'll just leave
+      // the level_name blank. That information isn't likely to get used by the
+      // fleet driver anyway.
+      if (wp.graph_index())
+      {
+        location.level_name =
+          _travel_info.graph->get_waypoint(*wp.graph_index()).get_map_name();
+      }
+
+      if (!wp.graph_index())
+      {
+        std::cerr << "Requested waypoint not on a graph index "
+                  << "but this is required by free_fleet manager\n";
+      }
+      else
+      {
+        free_fleet::Manager::NavigationPoint navigation_point {
+          wp.graph_index().value(), std::optional<double>{location.yaw},
+          wp.time()};
+        path.emplace_back(std::move(navigation_point));
+      }
+    }
+
+    _current_command_id = _manager.request_navigation(_travel_info.robot_name,
+        path);
+
+    if (!_current_command_id.has_value())
+    {
+      _travel_info.updater->interrupted();  // update position before this?
+      _clear_last_command();
+    }
+
+  }
+
+  void stop() final
+  {
+    // This is currently not used by the fleet drivers
+  }
+
+  class DockFinder : public rmf_traffic::agv::Graph::Lane::Executor
+  {
+  public:
+
+    bool is_dock = false;
+
+    DockFinder(const std::string& dock_name)
+    : _dock_name(std::move(dock_name))
+    {
+      // Do nothing
+    }
+
+    void execute(const Dock& dock) final
+    {
+      if (dock.dock_name() == _dock_name)
+        is_dock = true;
+    }
+
+    void execute(const Wait&) final {}
+    void execute(const DoorOpen&) final {}
+    void execute(const DoorClose&) final {}
+    void execute(const LiftSessionBegin&) final {}
+    void execute(const LiftMove&) final {}
+    void execute(const LiftDoorOpen&) final {}
+    void execute(const LiftSessionEnd&) final {}
+
+  private:
+    const std::string& _dock_name;
+  };
+
+  void dock(
+    const std::string& dock_name,
+    RequestCompleted docking_finished_callback) final
+  {
+    auto lock = _lock();
+    _clear_last_command();
+
+    _dock_finished_callback = std::move(docking_finished_callback);
+
+    // TODO(MXG): We should come up with a better way to identify the docking
+    // lanes.
+    DockFinder finder(dock_name);
+    _dock_target_wp = rmf_utils::nullopt;
+    for (std::size_t i = 0; i < _travel_info.graph->num_lanes(); ++i)
+    {
+      const auto& lane = _travel_info.graph->get_lane(i);
+      const auto entry_event = lane.entry().event();
+      if (entry_event)
+      {
+        entry_event->execute(finder);
+        if (finder.is_dock)
+        {
+          _dock_target_wp = lane.entry().waypoint_index();
+          break;
+        }
+      }
+    }
+
+    assert(_dock_target_wp);
+
+    const auto& wp = _travel_info.graph->get_waypoint(*_dock_target_wp);
+    const std::string wp_name = wp.name() ?
+      *wp.name() : std::to_string(wp.index());
+
+    RCLCPP_INFO(
+      _node->get_logger(),
+      "Requesting robot [%s] of [%s] to dock into waypoint [%s]",
+      _travel_info.robot_name.c_str(),
+      _travel_info.fleet_name.c_str(),
+      wp_name.c_str());
+
+    _current_command_id = _manager.request_dock(_travel_info.robot_name,
+        dock_name);
+    if (!_current_command_id.has_value())
+    {
+      RCLCPP_ERROR(
+        _node->get_logger(),
+        "Invalid dock request, a robot with the provided name [%s] does not exist",
+        _travel_info.robot_name.c_str());
+
+      _clear_last_command();
+    }
+  }
+
+  void update_state(const free_fleet::manager::RobotInfo& updated_robot_info)
+  {
+    auto lock = _lock();
+    _last_known_robot_info = updated_robot_info;
+    auto robot_state = updated_robot_info.state();
+
+    auto x = robot_state.location().coordinates()[0];
+    auto y = robot_state.location().coordinates()[1];
+
+    if (!robot_state.location().yaw().has_value())
+    {
+      RCLCPP_WARN(
+        _node->get_logger(),
+        "Robot is not reporting its yaw.");
+    }
+    auto yaw = robot_state.location().yaw().value_or(0.0);
+    auto map_name = robot_state.location().map_name();
+
+    rmf_fleet_msgs::msg::Location location;
+    location.x = x;
+    location.y = y;
+    location.yaw = yaw;
+
+    auto tracking_estimation = updated_robot_info.tracking_estimation();
+
+    std::vector<std::size_t> lanes;
+
+    // Update based on TrackingState
+    switch (tracking_estimation.first)
+    {
+      case free_fleet::manager::RobotInfo::TrackingState::OnWaypoint:
+        // std::cout << "OnWaypoint " << tracking_estimation.second << std::endl;
+        _travel_info.updater->update_position(tracking_estimation.second,
+          robot_state.location().yaw().value());
+        break;
+      case free_fleet::manager::RobotInfo::TrackingState::OnLane:
+        // std::cout << "OnLane " << tracking_estimation.second << std::endl;
+        lanes.push_back(tracking_estimation.second);
+        _travel_info.updater->update_position({x, y, yaw}, lanes);
+        break;
+      case free_fleet::manager::RobotInfo::TrackingState::Lost:
+        // std::cout << "Lost " << tracking_estimation.second << std::endl;
+        _travel_info.updater->update_position(map_name, {x, y, yaw});
+        break;
+    }
+
+    // Update battery soc
+    const double battery_soc = robot_state.battery_percent();
+    if (battery_soc >= 0.0 && battery_soc <= 1.0)
+    {
+      _travel_info.updater->update_battery_soc(battery_soc);
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        _node->get_logger(),
+        "Battery percentage reported by the robot is outside of the valid "
+        "range [0,1] and hence the battery soc will not be updated. It is "
+        "critical to update the battery soc with a valid battery percentage "
+        "for task allocation planning.");
+    }
+
+    // Reset these each time. They will get filled in by the estimation
+    // functions as necessary.
+    _travel_info.target_plan_index = std::nullopt;
+
+    if (_travel_info.path_finished_callback)
+    {
+      // If we have a path_finished_callback, then the robot should be
+      // following a path
+
+      // There should not be a docking command happening
+      assert(!_dock_finished_callback);
+
+      // The arrival estimator should be available
+      assert(_travel_info.next_arrival_estimator);
+
+      assert(updated_robot_info.state().command_id().has_value());
+
+      if (updated_robot_info.state().command_id().value() !=
+        _current_command_id)
+      {
+        // The robot has not received our path request yet
+        return;
+      }
+
+      if (robot_state.mode().mode() ==
+        free_fleet::messages::RobotMode::Mode::Error)
+      {
+        if (_interrupted)
+        {
+          // This interruption was already noticed
+          return;
+        }
+
+        RCLCPP_INFO(
+          _node->get_logger(),
+          "[%s] of fleet [%s] reported interruption",
+          _travel_info.fleet_name.c_str(),
+          _travel_info.robot_name.c_str());
+
+        _interrupted = true;
+        return _travel_info.updater->interrupted();
+      }
+
+      if (updated_robot_info.state().command_completed())
+      {
+        // The robot believes it has arrived at its destination.
+        _travel_info.path_finished_callback();
+        _travel_info.path_finished_callback = nullptr;
+        _travel_info.next_arrival_estimator = nullptr;
+        return;
+      }
+
+      // estimate_path_traveling
+      assert(robot_state.target_path_index().has_value());
+      _travel_info.target_plan_index = robot_state.target_path_index().value();
+      auto i_target_wp = robot_state.target_path_index().value();
+      const auto& target_wp = _travel_info.waypoints.at(i_target_wp);
+      const auto& p = target_wp.position();
+      const auto interp = rmf_traffic::agv::Interpolate::positions(
+        *_travel_info.traits,
+        std::chrono::steady_clock::now(), {{x, y, yaw}, p});
+      const auto next_arrival = interp.back().time() - interp.front().time();
+      const auto now = rmf_traffic_ros2::convert(_node->now());
+      if (target_wp.time() < now + next_arrival)
+      {
+        assert(_travel_info.next_arrival_estimator);
+        // It seems the robot cannot arrive on time, so we report the earliest that
+        // the robot can make it to its next target waypoint.
+        _travel_info.next_arrival_estimator(i_target_wp, next_arrival);
+      }
+      else
+      {
+        assert(_travel_info.next_arrival_estimator);
+        // It seems the robot will arrive on time, so we'll report that.
+        _travel_info.next_arrival_estimator(i_target_wp,
+          target_wp.time() - now);
+      }
+      return;
+    }
+    else if (_dock_finished_callback)
+    {
+      // If we have a _dock_finished_callback, then the robot should be docking
+      if (updated_robot_info.state().command_id().value() !=
+        _current_command_id)
+      {
+        // The robot has not received our path request yet
+        return;
+      }
+
+      if (updated_robot_info.state().command_completed())
+      {
+        _dock_finished_callback();
+        _dock_finished_callback = nullptr;
+        return;
+      }
+    }
+  }
+
+  void set_updater(rmf_fleet_adapter::agv::RobotUpdateHandlePtr updater)
+  {
+    _travel_info.updater = std::move(updater);
+  }
+
+  void newly_closed_lanes(const std::unordered_set<std::size_t>& closed_lanes)
+  {
+    bool need_to_replan = false;
+
+    if (_travel_info.target_plan_index.has_value())
+    {
+      const auto& target_wp =
+        _travel_info.waypoints.at(*_travel_info.target_plan_index);
+
+      const auto& current_lanes = target_wp.approach_lanes();
+      for (const auto& l : current_lanes)
+      {
+        if (closed_lanes.count(l))
+        {
+          need_to_replan = true;
+          const auto& lane = _travel_info.graph->get_lane(l);
+          const auto& loc = _last_known_robot_info->state().location();
+          const auto& coords = loc.coordinates();
+          const Eigen::Vector2d p = {coords[0], coords[1]};
+
+          const auto& wp0 =
+            _travel_info.graph->get_waypoint(lane.entry().waypoint_index());
+          const Eigen::Vector2d p0 = wp0.get_location();
+
+          const auto& wp1 =
+            _travel_info.graph->get_waypoint(lane.exit().waypoint_index());
+          const Eigen::Vector2d p1 = wp1.get_location();
+
+          const bool before_blocked_lane = (p-p0).dot(p1-p0) < 0.0;
+          const bool after_blocked_lane = (p-p1).dot(p1-p0) >= 0.0;
+          if (!before_blocked_lane && !after_blocked_lane)
+          {
+            // The robot is currently on a lane that has been closed. We take
+            // this to mean that the robot needs to reverse.
+            const Eigen::Vector3d position = {p.x(), p.y(), loc.yaw().value()};
+            const auto& return_waypoint = wp0.index();
+            const auto* reverse_lane =
+              _travel_info.graph->lane_from(wp1.index(), wp0.index());
+
+            if (reverse_lane)
+            {
+              // We know what lane will reverse us back to the beginning of our
+              // current lane, so we will update our position by saying that we
+              // are on that lane.
+              std::vector<std::size_t> lanes;
+              lanes.push_back(reverse_lane->index());
+              _travel_info.updater->update_position(position, lanes);
+            }
+            else
+            {
+              // There isn't an explicit lane for getting back to the beginning of
+              // our current lane, so we will update with only our current
+              // position and the waypoint index that we intend to return to.
+              _travel_info.updater->update_position(position, return_waypoint);
+            }
+          }
+        }
+      }
+    }
+
+    if (!need_to_replan && _travel_info.target_plan_index.has_value())
+    {
+      // Check if the remainder of the current plan has been invalidated by the
+      // lane closure.
+      const auto next_index = *_travel_info.target_plan_index;
+      for (std::size_t i = next_index; i < _travel_info.waypoints.size(); ++i)
+      {
+        for (const auto& lane : _travel_info.waypoints[i].approach_lanes())
+        {
+          if (closed_lanes.count(lane))
+          {
+            need_to_replan = true;
+            break;
+          }
+        }
+
+        if (need_to_replan)
+          break;
+      }
+    }
+
+    if (need_to_replan)
+      _travel_info.updater->interrupted();
+  }
+
+private:
+
+  rclcpp::Node* _node;
+  PathRequestPub _path_request_pub;
+  std::chrono::steady_clock::time_point _path_requested_time;
+  TravelInfo _travel_info;
+  std::optional<free_fleet::manager::RobotInfo> _last_known_robot_info;
+  bool _interrupted = false;
+
+  rmf_utils::optional<std::size_t> _dock_target_wp;
+  std::chrono::steady_clock::time_point _dock_requested_time;
+  std::chrono::steady_clock::time_point _dock_schedule_time =
+    std::chrono::steady_clock::now();
+  RequestCompleted _dock_finished_callback;
+  ModeRequestPub _mode_request_pub;
+  free_fleet::Manager& _manager;
+  uint32_t _current_task_id = 0;
+
+  std::optional<free_fleet::CommandId> _current_command_id; // from free_fleet Manager
+
+  std::mutex _mutex;
+
+  std::unique_lock<std::mutex> _lock()
+  {
+    std::unique_lock<std::mutex> lock(_mutex, std::defer_lock);
+    while (!lock.try_lock())
+    {
+      // Intentionally busy wait
+    }
+
+    return lock;
+  }
+
+  void _clear_last_command()
+  {
+    _travel_info.next_arrival_estimator = nullptr;
+    _travel_info.path_finished_callback = nullptr;
+    _dock_finished_callback = nullptr;
+  }
+};
+
+using FleetDriverRobotCommandHandlePtr =
+  std::shared_ptr<FleetDriverRobotCommandHandle>;
+
+//==============================================================================
+/// This is an RAII class that keeps the connections to the fleet driver alive.
+struct Connections : public std::enable_shared_from_this<Connections>
+{
+  /// The API for adding new robots to the adapter
+  rmf_fleet_adapter::agv::FleetUpdateHandlePtr fleet;
+
+  /// The API for running the fleet adapter
+  rmf_fleet_adapter::agv::AdapterPtr adapter;
+
+  /// The navigation graph for the robot
+  std::shared_ptr<const rmf_traffic::agv::Graph> graph;
+
+  /// The traits of the vehicles
+  std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits;
+
+  /// The topic subscription for responding to new fleet states
+  rclcpp::Subscription<rmf_fleet_msgs::msg::FleetState>::SharedPtr
+    fleet_state_sub;
+
+  /// The publisher for sending out path requests
+  rclcpp::Publisher<rmf_fleet_msgs::msg::PathRequest>::SharedPtr
+    path_request_pub;
+
+  /// The publisher for sending out mode requests
+  rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr
+    mode_request_pub;
+
+  /// The client for listening to whether there is clearance in a lift
+  rclcpp::Client<rmf_fleet_msgs::srv::LiftClearance>::SharedPtr
+    lift_watchdog_client;
+
+  /// The topic subscription for listening for lane closure requests
+  rclcpp::Subscription<rmf_fleet_msgs::msg::LaneRequest>::SharedPtr
+    lane_closure_request_sub;
+
+  /// The publisher for sending out closed lane statuses
+  rclcpp::Publisher<rmf_fleet_msgs::msg::ClosedLanes>::SharedPtr
+    closed_lanes_pub;
+
+  /// Container for remembering which lanes are currently closed
+  std::unordered_set<std::size_t> closed_lanes;
+
+  /// The container for robot update handles
+  std::unordered_map<std::string, FleetDriverRobotCommandHandlePtr>
+  robots;
+
+  std::shared_ptr<free_fleet::Manager> manager;
+
+  std::shared_ptr<free_fleet::Executor> executor;
+
+  void add_robot(
+    const std::string& fleet_name,
+    const free_fleet::manager::RobotInfo& robot_info
+  )
+  {
+    const auto& robot_name = robot_info.name();
+    const auto command = std::make_shared<FleetDriverRobotCommandHandle>(
+      *adapter->node(), fleet_name, robot_name, graph, traits,
+      path_request_pub, mode_request_pub, *(this->manager));
+
+    rmf_fleet_msgs::msg::Location location;
+    location.x = (float)robot_info.state().location().coordinates()[0];
+    location.y = (float)robot_info.state().location().coordinates()[1];
+    location.yaw = (float)robot_info.state().location().yaw().value();
+    location.level_name = robot_info.state().location().map_name();
+
+    const auto& l = location;
+    const auto& starts = rmf_traffic::agv::compute_plan_starts(
+      *graph, robot_info.state().location().map_name(), {l.x, l.y, l.yaw},
+      rmf_traffic_ros2::convert(adapter->node()->now()));
+
+    if (starts.empty())
+    {
+      const std::optional<DistanceFromGraph> distance =
+        distance_from_graph(location, *graph);
+
+      std::string hint;
+      if (!distance.has_value())
+      {
+        hint = "None of the waypoints in the graph are on a map called ["
+          + l.level_name + "].";
+      }
+      else
+      {
+        const auto to_name = [&](const std::size_t index) -> std::string
+          {
+            const auto& wp = graph->get_waypoint(index);
+            if (wp.name())
+              return *wp.name();
+
+            return "#" + std::to_string(index);
+          };
+
+        if (distance->type == DistanceFromGraph::Lane)
+        {
+          const auto& lane = graph->get_lane(distance->index);
+          hint = "The closest lane on the navigation graph ["
+            + std::to_string(distance->index) + "] connects waypoint ["
+            + to_name(lane.entry().waypoint_index()) + "] to ["
+            + to_name(lane.exit().waypoint_index()) + "] and is a distance of ["
+            + std::to_string(distance->value) + "m] from the robot.";
+        }
+        else
+        {
+          hint = "The closest waypoint on the navigation graph ["
+            + to_name(distance->index) + "] is a distance of ["
+            + std::to_string(distance->value) + "m] from the robot.";
+        }
+      }
+
+      RCLCPP_ERROR(
+        adapter->node()->get_logger(),
+        "Unable to compute a StartSet for robot [%s] using level_name [%s] and "
+        "location [%f, %f, %f] specified in its RobotState message. This can "
+        "happen if the level_name in the RobotState message does not match any "
+        "of the map names in the navigation graph supplied or if the location "
+        "reported in the RobotState message is far way from the navigation "
+        "graph. This robot will not be added to the fleet [%s]. The following "
+        "hint may help with debugging: %s",
+        robot_info.name().c_str(),
+        robot_info.state().location().map_name().c_str(),
+        l.x, l.y, l.yaw,
+        fleet_name.c_str(),
+        hint.c_str());
+
+      return;
+    }
+
+    fleet->add_robot(
+      command, robot_name, traits->profile(),
+      starts,
+      [c = weak_from_this(), command, robot_name = std::move(robot_name)](
+        const rmf_fleet_adapter::agv::RobotUpdateHandlePtr& updater)
+      {
+        const auto connections = c.lock();
+        if (!connections)
+          return;
+
+        auto lock = connections->lock();
+
+        if (connections->lift_watchdog_client)
+        {
+          updater->unstable().set_lift_entry_watchdog(
+            [robot_name, connections](
+              const std::string& lift_name,
+              auto decide)
+            {
+              auto request =
+              std::make_shared<rmf_fleet_msgs::srv::LiftClearance::Request>(
+                rmf_fleet_msgs::build<rmf_fleet_msgs::srv::LiftClearance::Request>()
+                .robot_name(robot_name)
+                .lift_name(lift_name));
+
+              const auto client = connections->lift_watchdog_client;
+              if (!client->service_is_ready())
+              {
+                RCLCPP_ERROR(
+                  connections->adapter->node()->get_logger(),
+                  "Failed to get lift clearance service");
+                decide(convert_decision(0));
+                return;
+              }
+
+              client->async_send_request(
+                request,
+                [decide](
+                  rclcpp::Client<rmf_fleet_msgs::srv::LiftClearance>::
+                  SharedFuture response)
+                {
+                  const auto r = response.get();
+                  decide(convert_decision(r->decision));
+                });
+            });
+        }
+
+        command->set_updater(updater);
+        connections->robots[robot_name] = command;
+      });
+  }
+
+  std::shared_ptr<free_fleet::Manager> make_manager(
+    const std::string& fleet_name,
+    const std::shared_ptr<const rmf_traffic::agv::Graph>& graph)
+  {
+    auto m = free_fleet::cyclonedds::ServerDDSMiddleware::make_unique(0,
+        fleet_name); // to do: dds domain as param
+    auto ct = free_fleet::manager::SimpleCoordinateTransformer::make(
+      1.0,
+      0.0,
+      0.0,
+      0.0);
+    free_fleet::Manager::TimeNow time_now_fn =
+      []() { return std::chrono::steady_clock::now(); };
+    free_fleet::Manager::RobotUpdatedCallback cb =
+      [c = weak_from_this(),
+        fleet_name](const free_fleet::manager::RobotInfo& updated_robot_info)
+      {
+        const auto connections = c.lock();
+        if (!connections)
+          return;
+
+        const auto insertion = connections->robots.insert(
+          {updated_robot_info.name(),
+            nullptr});
+        const bool new_robot = insertion.second;
+
+        if (new_robot)
+        {
+          // We have not seen this robot before, so let's add it to the fleet.
+          connections->add_robot(fleet_name, updated_robot_info);
+        }
+
+        const auto& command = insertion.first->second;
+        if (command)
+        {
+          // We are ready to command this robot, so let's update its state
+          command->update_state(updated_robot_info);
+        }
+      };
+
+    auto manager = free_fleet::Manager::make(
+      fleet_name,
+      graph,
+      std::move(m),
+      ct,
+      time_now_fn,
+      cb);
+
+    return manager;
+  }
+
+  std::mutex _mutex;
+  std::unique_lock<std::mutex> lock()
+  {
+    std::unique_lock<std::mutex> l(_mutex, std::defer_lock);
+    while (!l.try_lock())
+    {
+      // Intentionally busy wait
+    }
+
+    return l;
+  }
+};
+
+//==============================================================================
+std::shared_ptr<Connections> make_fleet(
+  const rmf_fleet_adapter::agv::AdapterPtr& adapter)
+{
+  const auto& node = adapter->node();
+  std::shared_ptr<Connections> connections = std::make_shared<Connections>();
+  connections->adapter = adapter;
+
+  const std::string fleet_name_param_name = "fleet_name";
+  const std::string fleet_name = node->declare_parameter(
+    "fleet_name", std::string());
+  if (fleet_name.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", fleet_name_param_name.c_str());
+
+    return nullptr;
+  }
+
+  connections->traits = std::make_shared<rmf_traffic::agv::VehicleTraits>(
+    rmf_fleet_adapter::get_traits_or_default(
+      *node, 0.7, 0.3, 0.5, 1.5, 0.5, 1.5));
+
+  const std::string nav_graph_param_name = "nav_graph_file";
+  const std::string graph_file =
+    node->declare_parameter(nav_graph_param_name, std::string());
+  if (graph_file.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", nav_graph_param_name.c_str());
+
+    return nullptr;
+  }
+
+  connections->graph =
+    std::make_shared<rmf_traffic::agv::Graph>(
+    rmf_fleet_adapter::agv::parse_graph(graph_file, *connections->traits));
+
+  std::cout << "The fleet [" << fleet_name
+            << "] has the following named waypoints:\n";
+  for (const auto& key : connections->graph->keys())
+    std::cout << " -- " << key.first << std::endl;
+
+  connections->fleet = adapter->add_fleet(
+    fleet_name, *connections->traits, *connections->graph);
+
+  // We disable fleet state publishing for this fleet adapter because we expect
+  // the fleet drivers to publish these messages.
+  connections->fleet->fleet_state_publish_period(std::nullopt);
+
+  connections->closed_lanes_pub =
+    adapter->node()->create_publisher<rmf_fleet_msgs::msg::ClosedLanes>(
+    rmf_fleet_adapter::ClosedLaneTopicName,
+    rclcpp::SystemDefaultsQoS().reliable().keep_last(1).transient_local());
+
+  connections->lane_closure_request_sub =
+    adapter->node()->create_subscription<rmf_fleet_msgs::msg::LaneRequest>(
+    rmf_fleet_adapter::LaneClosureRequestTopicName,
+    rclcpp::SystemDefaultsQoS(),
+    [w = connections->weak_from_this(), fleet_name](
+      rmf_fleet_msgs::msg::LaneRequest::UniquePtr request_msg)
+    {
+      const auto connections = w.lock();
+      if (!connections)
+        return;
+
+      if (request_msg->fleet_name != fleet_name &&
+      !request_msg->fleet_name.empty())
+        return;
+
+      connections->fleet->open_lanes(request_msg->open_lanes);
+      connections->fleet->close_lanes(request_msg->close_lanes);
+
+      std::unordered_set<std::size_t> newly_closed_lanes;
+      for (const auto& l : request_msg->close_lanes)
+      {
+        if (connections->closed_lanes.count(l) == 0)
+          newly_closed_lanes.insert(l);
+
+        connections->closed_lanes.insert(l);
+      }
+
+      for (const auto& l : request_msg->open_lanes)
+        connections->closed_lanes.erase(l);
+
+      for (auto& [_, robot] : connections->robots)
+        robot->newly_closed_lanes(newly_closed_lanes);
+
+      rmf_fleet_msgs::msg::ClosedLanes state_msg;
+      state_msg.fleet_name = fleet_name;
+      state_msg.closed_lanes.insert(
+        state_msg.closed_lanes.begin(),
+        connections->closed_lanes.begin(),
+        connections->closed_lanes.end());
+
+      connections->closed_lanes_pub->publish(state_msg);
+    });
+
+  // Parameters required for task planner
+  // Battery system
+  auto battery_system_optional = rmf_fleet_adapter::get_battery_system(
+    *node, 24.0, 40.0, 8.8);
+  if (!battery_system_optional)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for battery system");
+
+    return nullptr;
+  }
+  auto battery_system = std::make_shared<rmf_battery::agv::BatterySystem>(
+    *battery_system_optional);
+
+  // Mechanical system and motion_sink
+  auto mechanical_system_optional = rmf_fleet_adapter::get_mechanical_system(
+    *node, 70.0, 40.0, 0.22);
+  if (!mechanical_system_optional)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for mechanical system");
+
+    return nullptr;
+  }
+  rmf_battery::agv::MechanicalSystem& mechanical_system =
+    *mechanical_system_optional;
+
+  std::shared_ptr<rmf_battery::agv::SimpleMotionPowerSink> motion_sink =
+    std::make_shared<rmf_battery::agv::SimpleMotionPowerSink>(
+    *battery_system, mechanical_system);
+
+  // Ambient power system
+  const double ambient_power_drain =
+    rmf_fleet_adapter::get_parameter_or_default(
+    *node, "ambient_power_drain", 20.0);
+  auto ambient_power_system = rmf_battery::agv::PowerSystem::make(
+    ambient_power_drain);
+  if (!ambient_power_system)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for ambient power system");
+
+    return nullptr;
+  }
+  std::shared_ptr<rmf_battery::agv::SimpleDevicePowerSink> ambient_sink =
+    std::make_shared<rmf_battery::agv::SimpleDevicePowerSink>(
+    *battery_system, *ambient_power_system);
+
+  // Tool power system
+  const double tool_power_drain = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "tool_power_drain", 10.0);
+  auto tool_power_system = rmf_battery::agv::PowerSystem::make(
+    tool_power_drain);
+  if (!tool_power_system)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for tool power system");
+
+    return nullptr;
+  }
+  std::shared_ptr<rmf_battery::agv::SimpleDevicePowerSink> tool_sink =
+    std::make_shared<rmf_battery::agv::SimpleDevicePowerSink>(
+    *battery_system, *tool_power_system);
+
+  // Drain battery
+  const bool drain_battery = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "drain_battery", false);
+  // Recharge threshold
+  const double recharge_threshold = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "recharge_threshold", 0.2);
+  // Recharge state of charge
+  const double recharge_soc = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "recharge_soc", 1.0);
+  const std::string finishing_request_string =
+    node->declare_parameter("finishing_request", "nothing");
+  rmf_task::ConstRequestFactoryPtr finishing_request = nullptr;
+  if (finishing_request_string == "charge")
+  {
+    finishing_request =
+      std::make_shared<rmf_task::requests::ChargeBatteryFactory>();
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Fleet is configured to perform ChargeBattery as finishing request");
+  }
+  else if (finishing_request_string == "park")
+  {
+    finishing_request =
+      std::make_shared<rmf_task::requests::ParkRobotFactory>();
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Fleet is configured to perform ParkRobot as finishing request");
+  }
+  else if (finishing_request_string == "nothing")
+  {
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Fleet is not configured to perform any finishing request");
+  }
+  else
+  {
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Provided finishing request [%s] is unsupported. The valid "
+      "finishing requests are [charge, park, nothing]. The task planner will "
+      " default to [nothing].",
+      finishing_request_string.c_str());
+  }
+
+  if (!connections->fleet->set_task_planner_params(
+      battery_system,
+      motion_sink,
+      ambient_sink,
+      tool_sink,
+      recharge_threshold,
+      recharge_soc,
+      drain_battery,
+      finishing_request))
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Failed to initialize task planner parameters");
+
+    return nullptr;
+  }
+
+  std::unordered_set<uint8_t> task_types;
+  if (node->declare_parameter<bool>("perform_loop", false))
+  {
+    task_types.insert(rmf_task_msgs::msg::TaskType::TYPE_LOOP);
+  }
+
+  // If the perform_deliveries parameter is true, then we just blindly accept
+  // all delivery requests.
+  if (node->declare_parameter<bool>("perform_deliveries", false))
+  {
+    task_types.insert(rmf_task_msgs::msg::TaskType::TYPE_DELIVERY);
+    connections->fleet->accept_delivery_requests(
+      [](const rmf_task_msgs::msg::Delivery&) { return true; });
+  }
+
+  if (node->declare_parameter<bool>("perform_cleaning", false))
+  {
+    task_types.insert(rmf_task_msgs::msg::TaskType::TYPE_CLEAN);
+  }
+
+  connections->fleet->accept_task_requests(
+    [task_types](const rmf_task_msgs::msg::TaskProfile& msg)
+    {
+      if (task_types.find(msg.description.task_type.type) != task_types.end())
+        return true;
+
+      return false;
+    });
+
+  if (node->declare_parameter<bool>("disable_delay_threshold", false))
+  {
+    connections->fleet->default_maximum_delay(rmf_utils::nullopt);
+  }
+  else
+  {
+    connections->fleet->default_maximum_delay(
+      rmf_fleet_adapter::get_parameter_or_default_time(
+        *node, "delay_threshold", 10.0));
+  }
+
+  connections->path_request_pub = node->create_publisher<
+    rmf_fleet_msgs::msg::PathRequest>(
+    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS());
+
+  connections->mode_request_pub = node->create_publisher<
+    rmf_fleet_msgs::msg::ModeRequest>(
+    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS());
+
+  const std::string lift_clearance_srv =
+    node->declare_parameter<std::string>(
+    "experimental_lift_watchdog_service", "");
+  if (!lift_clearance_srv.empty())
+  {
+    connections->lift_watchdog_client =
+      node->create_client<rmf_fleet_msgs::srv::LiftClearance>(
+      lift_clearance_srv);
+  }
+
+  connections->manager = connections->make_manager(fleet_name,
+      connections->graph);
+
+  std::shared_ptr<free_fleet::Executor> executor =
+    std::make_shared<free_fleet::Executor>(
+    (std::unique_ptr<free_fleet::Worker>)connections->manager.get());
+  executor->start_async(std::chrono::nanoseconds((int)1e9));
+  connections->executor = executor;
+
+  return connections;
+}
+
+int main(int argc, char** argv)
+{
+
+  rclcpp::init(argc, argv);
+  const auto adapter = rmf_fleet_adapter::agv::Adapter::make("fleet_adapter");
+  if (!adapter)
+    return 1;
+
+  const auto fleet_connections = make_fleet(adapter);
+  if (!fleet_connections)
+    return 1;
+
+  RCLCPP_INFO(adapter->node()->get_logger(), "Starting Fleet Adapter");
+
+  // Start running the adapter and wait until it gets stopped by SIGINT
+  adapter->start().wait();
+
+  RCLCPP_INFO(adapter->node()->get_logger(), "Closing Fleet Adapter");
+
+  rclcpp::shutdown();
+  return 0;
+
+}

--- a/adapter/src/manager_standalone.cpp
+++ b/adapter/src/manager_standalone.cpp
@@ -1,0 +1,1222 @@
+#include <iostream>
+
+#include <rclcpp/rclcpp.hpp>
+
+// Public rmf_fleet_adapter API headers
+#include <rmf_fleet_adapter/agv/Adapter.hpp>
+#include <rmf_fleet_adapter/agv/parse_graph.hpp>
+
+// Standard topic names for communicating with fleet drivers
+#include <rmf_fleet_adapter/StandardNames.hpp>
+
+// Fleet driver state/command messages
+#include <rmf_fleet_msgs/msg/fleet_state.hpp>
+#include <rmf_fleet_msgs/msg/path_request.hpp>
+#include <rmf_fleet_msgs/msg/mode_request.hpp>
+#include <rmf_fleet_msgs/srv/lift_clearance.hpp>
+#include <rmf_fleet_msgs/msg/lane_request.hpp>
+#include <rmf_fleet_msgs/msg/closed_lanes.hpp>
+
+// RMF Task messages
+#include <rmf_task_msgs/msg/task_type.hpp>
+#include <rmf_task_msgs/msg/task_profile.hpp>
+
+// ROS2 utilities for rmf_traffic
+#include <rmf_traffic_ros2/Time.hpp>
+
+// Public rmf_task API headers
+#include <rmf_task/requests/ChargeBatteryFactory.hpp>
+#include <rmf_task/requests/ParkRobotFactory.hpp>
+
+// Public rmf_traffic API headers
+#include <rmf_traffic/agv/Interpolate.hpp>
+#include <rmf_traffic/Route.hpp>
+
+#include <rmf_battery/agv/BatterySystem.hpp>
+#include <rmf_battery/agv/SimpleMotionPowerSink.hpp>
+#include <rmf_battery/agv/SimpleDevicePowerSink.hpp>
+
+#include <Eigen/Geometry>
+#include <unordered_set>
+
+#include <free_fleet/manager/Manager.hpp>
+#include <free_fleet/manager/SimpleCoordinateTransformer.hpp>
+
+#include <free_fleet_cyclonedds/ServerDDSMiddleware.hpp>
+
+
+// #include "FleetDriverRobotCommandHandle.hpp"
+
+#include "estimation.hpp"
+#include "load_param.hpp"
+
+#include <dds/dds.h>
+
+//==============================================================================
+rmf_fleet_adapter::agv::RobotUpdateHandle::Unstable::Decision
+convert_decision(uint32_t decision)
+{
+  using namespace rmf_fleet_adapter::agv;
+  switch (decision)
+  {
+    case rmf_fleet_msgs::srv::LiftClearance::Response::DECISION_CLEAR:
+      return RobotUpdateHandle::Unstable::Decision::Clear;
+    case rmf_fleet_msgs::srv::LiftClearance::Response::DECISION_CROWDED:
+      return RobotUpdateHandle::Unstable::Decision::Crowded;
+  }
+
+  std::cerr << "Received undefined value for lift clearance service: "
+            << decision << std::endl;
+  return RobotUpdateHandle::Unstable::Decision::Undefined;
+}
+
+//==============================================================================
+struct DistanceFromGraph
+{
+  double value;
+  std::size_t index;
+
+  enum Type
+  {
+    Waypoint = 0,
+    Lane
+  };
+  Type type;
+};
+
+//==============================================================================
+std::optional<DistanceFromGraph> distance_from_graph(
+  const rmf_fleet_msgs::msg::Location& l,
+  const rmf_traffic::agv::Graph& graph)
+{
+  std::optional<DistanceFromGraph> output;
+  const Eigen::Vector2d p = {l.x, l.y};
+  const std::string& map = l.level_name;
+
+  for (std::size_t i = 0; i < graph.num_waypoints(); ++i)
+  {
+    const auto& wp = graph.get_waypoint(i);
+    if (wp.get_map_name() != map)
+      continue;
+
+    const double dist = (wp.get_location() - p).norm();
+    if (!output.has_value() || (dist < output->value))
+    {
+      output = DistanceFromGraph{dist, i, DistanceFromGraph::Waypoint};
+    }
+  }
+
+  for (std::size_t i = 0; i < graph.num_lanes(); ++i)
+  {
+    const auto& lane = graph.get_lane(i);
+    const auto& wp0 = graph.get_waypoint(lane.entry().waypoint_index());
+    const auto& wp1 = graph.get_waypoint(lane.exit().waypoint_index());
+
+    if (map != wp0.get_map_name() && map != wp1.get_map_name())
+      continue;
+
+    const Eigen::Vector2d p0 = wp0.get_location();
+    const Eigen::Vector2d p1 = wp1.get_location();
+
+    const Eigen::Vector2d dp = p - p0;
+    const Eigen::Vector2d dp1 = p1 - p0;
+
+    const double lane_length = dp1.norm();
+    if (lane_length < 1e-8)
+      continue;
+
+    const double u = dp.dot(dp1)/lane_length;
+    if (u < 0 || lane_length < u)
+      continue;
+
+    const double dist = (dp - u*dp1/lane_length).norm();
+    if (!output.has_value() || (dist < output->value))
+    {
+      output = DistanceFromGraph{dist, i, DistanceFromGraph::Lane};
+    }
+  }
+
+  return output;
+}
+
+//==============================================================================
+class FleetDriverRobotCommandHandle
+  : public rmf_fleet_adapter::agv::RobotCommandHandle
+{
+public:
+
+  using PathRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::PathRequest>::SharedPtr;
+
+  using ModeRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr;
+
+  FleetDriverRobotCommandHandle(
+    rclcpp::Node& node,
+    std::string fleet_name,
+    std::string robot_name,
+    std::shared_ptr<const rmf_traffic::agv::Graph> graph,
+    std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits,
+    PathRequestPub path_request_pub,
+    ModeRequestPub mode_request_pub,
+    std::shared_ptr<free_fleet::Manager> manager)
+  : _node(&node),
+    _robot_name(robot_name),
+    _path_request_pub(std::move(path_request_pub)),
+    _mode_request_pub(std::move(mode_request_pub)),
+    _manager(std::move(manager))
+  {
+    _current_path_request.fleet_name = fleet_name;
+    _current_path_request.robot_name = robot_name;
+
+    _current_dock_request.fleet_name = fleet_name;
+    _current_dock_request.robot_name = robot_name;
+    _current_dock_request.mode.mode = _current_dock_request.mode.MODE_DOCKING;
+
+    rmf_fleet_msgs::msg::ModeParameter p;
+    p.name = "docking";
+    _current_dock_request.parameters.push_back(std::move(p));
+
+    _travel_info.graph = std::move(graph);
+    _travel_info.traits = std::move(traits);
+    _travel_info.fleet_name = std::move(fleet_name);
+    _travel_info.robot_name = std::move(robot_name);
+  }
+
+  void follow_new_path(
+    const std::vector<rmf_traffic::agv::Plan::Waypoint>& waypoints,
+    ArrivalEstimator next_arrival_estimator,
+    RequestCompleted path_finished_callback) final
+  {
+    auto lock = _lock();
+    _clear_last_command();
+
+    _travel_info.target_plan_index = std::nullopt;
+    _travel_info.waypoints = waypoints;
+    _travel_info.next_arrival_estimator = std::move(next_arrival_estimator);
+    _travel_info.path_finished_callback = std::move(path_finished_callback);
+    _interrupted = false;
+
+    _current_path_request.task_id = std::to_string(++_current_task_id);
+    _current_path_request.path.clear();
+
+    std::vector<free_fleet::Manager::NavigationPoint> path;
+
+    for (const auto& wp : waypoints)
+    {
+      rmf_fleet_msgs::msg::Location location;
+      const Eigen::Vector3d p = wp.position();
+      location.t = rmf_traffic_ros2::convert(wp.time());
+      location.x = p.x();
+      location.y = p.y();
+      location.yaw = p.z();
+
+      // Note: if the waypoint is not on a graph index, then we'll just leave
+      // the level_name blank. That information isn't likely to get used by the
+      // fleet driver anyway.
+      if (wp.graph_index())
+      {
+        location.level_name =
+          _travel_info.graph->get_waypoint(*wp.graph_index()).get_map_name();
+      }
+
+      _current_path_request.path.emplace_back(std::move(location));
+      if (!wp.graph_index())
+      {
+        std::cout << "requested waypoint not on graph index\n";
+      }
+      else
+      {
+        free_fleet::Manager::NavigationPoint navigation_point {
+          wp.graph_index().value(), std::optional<double>{0.0} };
+        path.emplace_back(std::move(navigation_point));
+      }
+
+
+    }
+
+    _path_requested_time = std::chrono::steady_clock::now();
+    // _path_request_pub->publish(_current_path_request);
+    _manager->request_navigation(_robot_name, path);
+  }
+
+  void stop() final
+  {
+    // This is currently not used by the fleet drivers
+  }
+
+  class DockFinder : public rmf_traffic::agv::Graph::Lane::Executor
+  {
+  public:
+
+    bool is_dock = false;
+
+    DockFinder(const std::string& dock_name)
+    : _dock_name(std::move(dock_name))
+    {
+      // Do nothing
+    }
+
+    void execute(const Dock& dock) final
+    {
+      if (dock.dock_name() == _dock_name)
+        is_dock = true;
+    }
+
+    void execute(const Wait&) final {}
+    void execute(const DoorOpen&) final {}
+    void execute(const DoorClose&) final {}
+    void execute(const LiftSessionBegin&) final {}
+    void execute(const LiftMove&) final {}
+    void execute(const LiftDoorOpen&) final {}
+    void execute(const LiftSessionEnd&) final {}
+
+  private:
+    const std::string& _dock_name;
+  };
+
+  void dock(
+    const std::string& dock_name,
+    RequestCompleted docking_finished_callback) final
+  {
+    auto lock = _lock();
+    _clear_last_command();
+
+    _dock_finished_callback = std::move(docking_finished_callback);
+    _current_dock_request.parameters.front().value = dock_name;
+    _current_dock_request.task_id = std::to_string(++_current_task_id);
+
+    _dock_requested_time = std::chrono::steady_clock::now();
+    _mode_request_pub->publish(_current_dock_request);
+
+    // TODO(MXG): We should come up with a better way to identify the docking
+    // lanes.
+    DockFinder finder(dock_name);
+    _dock_target_wp = rmf_utils::nullopt;
+    for (std::size_t i = 0; i < _travel_info.graph->num_lanes(); ++i)
+    {
+      const auto& lane = _travel_info.graph->get_lane(i);
+      const auto entry_event = lane.entry().event();
+      if (entry_event)
+      {
+        entry_event->execute(finder);
+        if (finder.is_dock)
+        {
+          _dock_target_wp = lane.entry().waypoint_index();
+          break;
+        }
+      }
+    }
+
+    assert(_dock_target_wp);
+
+    const auto& wp = _travel_info.graph->get_waypoint(*_dock_target_wp);
+    const std::string wp_name = wp.name() ?
+      *wp.name() : std::to_string(wp.index());
+
+    RCLCPP_INFO(
+      _node->get_logger(),
+      "Requesting robot [%s] of [%s] to dock into waypoint [%s]",
+      _current_path_request.robot_name.c_str(),
+      _current_path_request.fleet_name.c_str(),
+      wp_name.c_str());
+  }
+
+  void update_state(const rmf_fleet_msgs::msg::RobotState& state)
+  {
+    auto lock = _lock();
+    _last_known_state = state;
+
+    // Update battery soc
+    const double battery_soc = state.battery_percent / 100.0;
+    if (battery_soc >= 0.0 && battery_soc <= 1.0)
+    {
+      _travel_info.updater->update_battery_soc(battery_soc);
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        _node->get_logger(),
+        "Battery percentage reported by the robot is outside of the valid "
+        "range [0,100] and hence the battery soc will not be updated. It is "
+        "critical to update the battery soc with a valid battery percentage "
+        "for task allocation planning.");
+    }
+
+    // Reset these each time. They will get filled in by the estimation
+    // functions as necessary.
+    _travel_info.target_plan_index = std::nullopt;
+
+    if (_travel_info.path_finished_callback)
+    {
+      // If we have a path_finished_callback, then the robot should be
+      // following a path
+
+      // There should not be a docking command happening
+      assert(!_dock_finished_callback);
+
+      // The arrival estimator should be available
+      assert(_travel_info.next_arrival_estimator);
+
+      if (state.task_id != _current_path_request.task_id)
+      {
+        // The robot has not received our path request yet
+        const auto now = std::chrono::steady_clock::now();
+        if (std::chrono::milliseconds(200) < now - _path_requested_time)
+        {
+          // We published the request a while ago, so we'll send it again in
+          // case it got dropped.
+          _path_requested_time = now;
+          // _path_request_pub->publish(_current_path_request);
+        }
+
+        return estimate_state(_node, state.location, _travel_info);
+      }
+
+      if (state.mode.mode == state.mode.MODE_ADAPTER_ERROR)
+      {
+        if (_interrupted)
+        {
+          // This interruption was already noticed
+          return;
+        }
+
+        RCLCPP_INFO(
+          _node->get_logger(),
+          "Fleet driver [%s] reported interruption for [%s]",
+          _current_path_request.fleet_name.c_str(),
+          _current_path_request.robot_name.c_str());
+
+        _interrupted = true;
+        estimate_state(_node, state.location, _travel_info);
+        return _travel_info.updater->interrupted();
+      }
+
+      if (state.path.empty())
+      {
+        // When the state path is empty, that means the robot believes it has
+        // arrived at its destination.
+        return check_path_finish(_node, state, _travel_info);
+      }
+
+      return estimate_path_traveling(_node, state, _travel_info);
+    }
+    else if (_dock_finished_callback)
+    {
+      const auto now = std::chrono::steady_clock::now();
+      // If we have a _dock_finished_callback, then the robot should be docking
+      if (state.task_id != _current_dock_request.task_id)
+      {
+        if (std::chrono::milliseconds(200) < now - _dock_requested_time)
+        {
+          // We published the request a while ago, so we'll send it again in
+          // case it got dropped.
+          _dock_requested_time = now;
+          _mode_request_pub->publish(_current_dock_request);
+        }
+
+        return;
+      }
+
+      if (state.mode.mode != state.mode.MODE_DOCKING)
+      {
+        estimate_waypoint(_node, state.location, _travel_info);
+        _travel_info.last_known_wp = *_dock_target_wp;
+        _dock_finished_callback();
+        _dock_finished_callback = nullptr;
+
+        return;
+      }
+
+      // Update the schedule with the docking path of the robot
+      if (!state.path.empty() &&
+        std::chrono::seconds(1) < now - _dock_schedule_time)
+      {
+        std::vector<Eigen::Vector3d> positions;
+        positions.push_back(
+          {state.location.x, state.location.y, state.location.yaw});
+        for (const auto& p : state.path)
+          positions.push_back({p.x, p.y, p.yaw});
+
+        const rmf_traffic::Trajectory trajectory =
+          rmf_traffic::agv::Interpolate::positions(
+          *_travel_info.traits,
+          rmf_traffic_ros2::convert(state.location.t),
+          positions);
+
+        if (trajectory.size() < 2)
+          return;
+
+        if (auto participant =
+          _travel_info.updater->unstable().get_participant())
+        {
+          participant->set(
+            {rmf_traffic::Route{state.location.level_name, trajectory}});
+          _dock_schedule_time = now;
+        }
+      }
+    }
+    else
+    {
+      // If we don't have a finishing callback, then the robot is not under our
+      // command
+      estimate_state(_node, state.location, _travel_info);
+    }
+  }
+
+  void set_updater(rmf_fleet_adapter::agv::RobotUpdateHandlePtr updater)
+  {
+    _travel_info.updater = std::move(updater);
+  }
+
+  void newly_closed_lanes(const std::unordered_set<std::size_t>& closed_lanes)
+  {
+    bool need_to_replan = false;
+
+    if (_travel_info.target_plan_index.has_value())
+    {
+      const auto& target_wp =
+        _travel_info.waypoints.at(*_travel_info.target_plan_index);
+
+      const auto& current_lanes = target_wp.approach_lanes();
+      for (const auto& l : current_lanes)
+      {
+        if (closed_lanes.count(l))
+        {
+          need_to_replan = true;
+          const auto& lane = _travel_info.graph->get_lane(l);
+          const auto& loc = _last_known_state->location;
+          const Eigen::Vector2d p = {loc.x, loc.y};
+
+          const auto& wp0 =
+            _travel_info.graph->get_waypoint(lane.entry().waypoint_index());
+          const Eigen::Vector2d p0 = wp0.get_location();
+
+          const auto& wp1 =
+            _travel_info.graph->get_waypoint(lane.exit().waypoint_index());
+          const Eigen::Vector2d p1 = wp1.get_location();
+
+          const bool before_blocked_lane = (p-p0).dot(p1-p0) < 0.0;
+          const bool after_blocked_lane = (p-p1).dot(p1-p0) >= 0.0;
+          if (!before_blocked_lane && !after_blocked_lane)
+          {
+            // The robot is currently on a lane that has been closed. We take
+            // this to mean that the robot needs to reverse.
+            const Eigen::Vector3d position = {p.x(), p.y(), loc.yaw};
+            const auto& return_waypoint = wp0.index();
+            const auto* reverse_lane =
+              _travel_info.graph->lane_from(wp1.index(), wp0.index());
+
+            if (reverse_lane)
+            {
+              // We know what lane will reverse us back to the beginning of our
+              // current lane, so we will update our position by saying that we
+              // are on that lane.
+              std::vector<std::size_t> lanes;
+              lanes.push_back(reverse_lane->index());
+              _travel_info.updater->update_position(position, lanes);
+            }
+            else
+            {
+              // There isn't an explicit lane for getting back to the beginning of
+              // our current lane, so we will update with only our current
+              // position and the waypoint index that we intend to return to.
+              _travel_info.updater->update_position(position, return_waypoint);
+            }
+          }
+        }
+      }
+    }
+
+    if (!need_to_replan && _travel_info.target_plan_index.has_value())
+    {
+      // Check if the remainder of the current plan has been invalidated by the
+      // lane closure.
+      const auto next_index = *_travel_info.target_plan_index;
+      for (std::size_t i = next_index; i < _travel_info.waypoints.size(); ++i)
+      {
+        for (const auto& lane : _travel_info.waypoints[i].approach_lanes())
+        {
+          if (closed_lanes.count(lane))
+          {
+            need_to_replan = true;
+            break;
+          }
+        }
+
+        if (need_to_replan)
+          break;
+      }
+    }
+
+    if (need_to_replan)
+      _travel_info.updater->interrupted();
+  }
+
+private:
+
+  rclcpp::Node* _node;
+  std::string _robot_name;
+  PathRequestPub _path_request_pub;
+  rmf_fleet_msgs::msg::PathRequest _current_path_request;
+  std::chrono::steady_clock::time_point _path_requested_time;
+  TravelInfo _travel_info;
+  std::optional<rmf_fleet_msgs::msg::RobotState> _last_known_state;
+  bool _interrupted = false;
+
+  rmf_fleet_msgs::msg::ModeRequest _current_dock_request;
+  rmf_utils::optional<std::size_t> _dock_target_wp;
+  std::chrono::steady_clock::time_point _dock_requested_time;
+  std::chrono::steady_clock::time_point _dock_schedule_time =
+    std::chrono::steady_clock::now();
+  RequestCompleted _dock_finished_callback;
+  ModeRequestPub _mode_request_pub;
+  std::shared_ptr<free_fleet::Manager> _manager;
+  uint32_t _current_task_id = 0;
+
+  std::mutex _mutex;
+
+  std::unique_lock<std::mutex> _lock()
+  {
+    std::unique_lock<std::mutex> lock(_mutex, std::defer_lock);
+    while (!lock.try_lock())
+    {
+      // Intentionally busy wait
+    }
+
+    return lock;
+  }
+
+  void _clear_last_command()
+  {
+    _travel_info.next_arrival_estimator = nullptr;
+    _travel_info.path_finished_callback = nullptr;
+    _dock_finished_callback = nullptr;
+  }
+};
+
+using FleetDriverRobotCommandHandlePtr =
+  std::shared_ptr<FleetDriverRobotCommandHandle>;
+
+//==============================================================================
+/// This is an RAII class that keeps the connections to the fleet driver alive.
+struct Connections : public std::enable_shared_from_this<Connections>
+{
+  /// The API for adding new robots to the adapter
+  rmf_fleet_adapter::agv::FleetUpdateHandlePtr fleet;
+
+  /// The API for running the fleet adapter
+  rmf_fleet_adapter::agv::AdapterPtr adapter;
+
+  /// The navigation graph for the robot
+  std::shared_ptr<const rmf_traffic::agv::Graph> graph;
+
+  /// The traits of the vehicles
+  std::shared_ptr<const rmf_traffic::agv::VehicleTraits> traits;
+
+  /// The topic subscription for responding to new fleet states
+  rclcpp::Subscription<rmf_fleet_msgs::msg::FleetState>::SharedPtr
+    fleet_state_sub;
+
+  /// The publisher for sending out path requests
+  rclcpp::Publisher<rmf_fleet_msgs::msg::PathRequest>::SharedPtr
+    path_request_pub;
+
+  /// The publisher for sending out mode requests
+  rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr
+    mode_request_pub;
+
+  /// The client for listening to whether there is clearance in a lift
+  rclcpp::Client<rmf_fleet_msgs::srv::LiftClearance>::SharedPtr
+    lift_watchdog_client;
+
+  /// The topic subscription for listening for lane closure requests
+  rclcpp::Subscription<rmf_fleet_msgs::msg::LaneRequest>::SharedPtr
+    lane_closure_request_sub;
+
+  /// The publisher for sending out closed lane statuses
+  rclcpp::Publisher<rmf_fleet_msgs::msg::ClosedLanes>::SharedPtr
+    closed_lanes_pub;
+
+  /// Container for remembering which lanes are currently closed
+  std::unordered_set<std::size_t> closed_lanes;
+
+  /// The container for robot update handles
+  std::unordered_map<std::string, FleetDriverRobotCommandHandlePtr>
+  robots;
+
+  std::shared_ptr<free_fleet::Manager> manager;
+
+  void add_robot(
+    const std::string& fleet_name,
+    const rmf_fleet_msgs::msg::RobotState& state)
+  {
+    const auto& robot_name = state.name;
+    const auto command = std::make_shared<FleetDriverRobotCommandHandle>(
+      *adapter->node(), fleet_name, robot_name, graph, traits,
+      path_request_pub, mode_request_pub, this->manager);
+
+    const auto& l = state.location;
+    const auto& starts = rmf_traffic::agv::compute_plan_starts(
+      *graph, state.location.level_name, {l.x, l.y, l.yaw},
+      rmf_traffic_ros2::convert(adapter->node()->now()));
+
+    if (starts.empty())
+    {
+      const std::optional<DistanceFromGraph> distance =
+        distance_from_graph(state.location, *graph);
+
+      std::string hint;
+      if (!distance.has_value())
+      {
+        hint = "None of the waypoints in the graph are on a map called ["
+          + l.level_name + "].";
+      }
+      else
+      {
+        const auto to_name = [&](const std::size_t index) -> std::string
+          {
+            const auto& wp = graph->get_waypoint(index);
+            if (wp.name())
+              return *wp.name();
+
+            return "#" + std::to_string(index);
+          };
+
+        if (distance->type == DistanceFromGraph::Lane)
+        {
+          const auto& lane = graph->get_lane(distance->index);
+          hint = "The closest lane on the navigation graph ["
+            + std::to_string(distance->index) + "] connects waypoint ["
+            + to_name(lane.entry().waypoint_index()) + "] to ["
+            + to_name(lane.exit().waypoint_index()) + "] and is a distance of ["
+            + std::to_string(distance->value) + "m] from the robot.";
+        }
+        else
+        {
+          hint = "The closest waypoint on the navigation graph ["
+            + to_name(distance->index) + "] is a distance of ["
+            + std::to_string(distance->value) + "m] from the robot.";
+        }
+      }
+
+      RCLCPP_ERROR(
+        adapter->node()->get_logger(),
+        "Unable to compute a StartSet for robot [%s] using level_name [%s] and "
+        "location [%f, %f, %f] specified in its RobotState message. This can "
+        "happen if the level_name in the RobotState message does not match any "
+        "of the map names in the navigation graph supplied or if the location "
+        "reported in the RobotState message is far way from the navigation "
+        "graph. This robot will not be added to the fleet [%s]. The following "
+        "hint may help with debugging: %s",
+        state.name.c_str(),
+        state.location.level_name.c_str(),
+        l.x, l.y, l.yaw,
+        fleet_name.c_str(),
+        hint.c_str());
+
+      return;
+    }
+
+    fleet->add_robot(
+      command, robot_name, traits->profile(),
+      starts,
+      [c = weak_from_this(), command, robot_name = std::move(robot_name)](
+        const rmf_fleet_adapter::agv::RobotUpdateHandlePtr& updater)
+      {
+        const auto connections = c.lock();
+        if (!connections)
+          return;
+
+        auto lock = connections->lock();
+
+        if (connections->lift_watchdog_client)
+        {
+          updater->unstable().set_lift_entry_watchdog(
+            [robot_name, connections](
+              const std::string& lift_name,
+              auto decide)
+            {
+              auto request =
+              std::make_shared<rmf_fleet_msgs::srv::LiftClearance::Request>(
+                rmf_fleet_msgs::build<rmf_fleet_msgs::srv::LiftClearance::Request>()
+                .robot_name(robot_name)
+                .lift_name(lift_name));
+
+              const auto client = connections->lift_watchdog_client;
+              if (!client->service_is_ready())
+              {
+                RCLCPP_ERROR(
+                  connections->adapter->node()->get_logger(),
+                  "Failed to get lift clearance service");
+                decide(convert_decision(0));
+                return;
+              }
+
+              client->async_send_request(
+                request,
+                [decide](
+                  rclcpp::Client<rmf_fleet_msgs::srv::LiftClearance>::
+                  SharedFuture response)
+                {
+                  const auto r = response.get();
+                  decide(convert_decision(r->decision));
+                });
+            });
+        }
+
+        command->set_updater(updater);
+        connections->robots[robot_name] = command;
+      });
+  }
+
+  std::mutex _mutex;
+  std::unique_lock<std::mutex> lock()
+  {
+    std::unique_lock<std::mutex> l(_mutex, std::defer_lock);
+    while (!l.try_lock())
+    {
+      // Intentionally busy wait
+    }
+
+    return l;
+  }
+};
+
+std::shared_ptr<free_fleet::Manager> make_manager(
+  const std::string& fleet_name,
+  const std::shared_ptr<const rmf_traffic::agv::Graph>& graph)
+{
+  auto m = free_fleet::cyclonedds::ServerDDSMiddleware::make_unique(0,
+      fleet_name); // to do: dds domain as param
+
+  auto ct = free_fleet::manager::SimpleCoordinateTransformer::make(
+    1.0,
+    0.0,
+    0.0,
+    0.0);
+  free_fleet::Manager::TimeNow time_now_fn =
+    []() { return std::chrono::steady_clock::now(); };
+  free_fleet::Manager::RobotUpdatedCallback cb =
+    [](const free_fleet::manager::RobotInfo& updated_robot_info)
+    {
+      std::cout << updated_robot_info.name() << " updated state\n";
+    };
+
+  auto manager = free_fleet::Manager::make(
+    fleet_name,
+    graph,
+    std::move(m),
+    ct,
+    time_now_fn,
+    cb);
+
+  return manager;
+}
+
+//==============================================================================
+std::shared_ptr<Connections> make_fleet(
+  const rmf_fleet_adapter::agv::AdapterPtr& adapter)
+{
+  const auto& node = adapter->node();
+  std::shared_ptr<Connections> connections = std::make_shared<Connections>();
+  connections->adapter = adapter;
+
+  const std::string fleet_name_param_name = "fleet_name";
+  const std::string fleet_name = node->declare_parameter(
+    "fleet_name", std::string());
+  if (fleet_name.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", fleet_name_param_name.c_str());
+
+    return nullptr;
+  }
+
+  connections->traits = std::make_shared<rmf_traffic::agv::VehicleTraits>(
+    rmf_fleet_adapter::get_traits_or_default(
+      *node, 0.7, 0.3, 0.5, 1.5, 0.5, 1.5));
+
+  const std::string nav_graph_param_name = "nav_graph_file";
+  const std::string graph_file =
+    node->declare_parameter(nav_graph_param_name, std::string());
+  if (graph_file.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", nav_graph_param_name.c_str());
+
+    return nullptr;
+  }
+
+  connections->graph =
+    std::make_shared<rmf_traffic::agv::Graph>(
+    rmf_fleet_adapter::agv::parse_graph(graph_file, *connections->traits));
+
+  std::cout << "The fleet [" << fleet_name
+            << "] has the following named waypoints:\n";
+  for (const auto& key : connections->graph->keys())
+    std::cout << " -- " << key.first << std::endl;
+
+  connections->fleet = adapter->add_fleet(
+    fleet_name, *connections->traits, *connections->graph);
+
+  // We disable fleet state publishing for this fleet adapter because we expect
+  // the fleet drivers to publish these messages.
+  connections->fleet->fleet_state_publish_period(std::nullopt);
+
+  connections->closed_lanes_pub =
+    adapter->node()->create_publisher<rmf_fleet_msgs::msg::ClosedLanes>(
+    rmf_fleet_adapter::ClosedLaneTopicName,
+    rclcpp::SystemDefaultsQoS().reliable().keep_last(1).transient_local());
+
+  connections->lane_closure_request_sub =
+    adapter->node()->create_subscription<rmf_fleet_msgs::msg::LaneRequest>(
+    rmf_fleet_adapter::LaneClosureRequestTopicName,
+    rclcpp::SystemDefaultsQoS(),
+    [w = connections->weak_from_this(), fleet_name](
+      rmf_fleet_msgs::msg::LaneRequest::UniquePtr request_msg)
+    {
+      const auto connections = w.lock();
+      if (!connections)
+        return;
+
+      if (request_msg->fleet_name != fleet_name &&
+      !request_msg->fleet_name.empty())
+        return;
+
+      connections->fleet->open_lanes(request_msg->open_lanes);
+      connections->fleet->close_lanes(request_msg->close_lanes);
+
+      std::unordered_set<std::size_t> newly_closed_lanes;
+      for (const auto& l : request_msg->close_lanes)
+      {
+        if (connections->closed_lanes.count(l) == 0)
+          newly_closed_lanes.insert(l);
+
+        connections->closed_lanes.insert(l);
+      }
+
+      for (const auto& l : request_msg->open_lanes)
+        connections->closed_lanes.erase(l);
+
+      for (auto& [_, robot] : connections->robots)
+        robot->newly_closed_lanes(newly_closed_lanes);
+
+      rmf_fleet_msgs::msg::ClosedLanes state_msg;
+      state_msg.fleet_name = fleet_name;
+      state_msg.closed_lanes.insert(
+        state_msg.closed_lanes.begin(),
+        connections->closed_lanes.begin(),
+        connections->closed_lanes.end());
+
+      connections->closed_lanes_pub->publish(state_msg);
+    });
+
+  // Parameters required for task planner
+  // Battery system
+  auto battery_system_optional = rmf_fleet_adapter::get_battery_system(
+    *node, 24.0, 40.0, 8.8);
+  if (!battery_system_optional)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for battery system");
+
+    return nullptr;
+  }
+  auto battery_system = std::make_shared<rmf_battery::agv::BatterySystem>(
+    *battery_system_optional);
+
+  // Mechanical system and motion_sink
+  auto mechanical_system_optional = rmf_fleet_adapter::get_mechanical_system(
+    *node, 70.0, 40.0, 0.22);
+  if (!mechanical_system_optional)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for mechanical system");
+
+    return nullptr;
+  }
+  rmf_battery::agv::MechanicalSystem& mechanical_system =
+    *mechanical_system_optional;
+
+  std::shared_ptr<rmf_battery::agv::SimpleMotionPowerSink> motion_sink =
+    std::make_shared<rmf_battery::agv::SimpleMotionPowerSink>(
+    *battery_system, mechanical_system);
+
+  // Ambient power system
+  const double ambient_power_drain =
+    rmf_fleet_adapter::get_parameter_or_default(
+    *node, "ambient_power_drain", 20.0);
+  auto ambient_power_system = rmf_battery::agv::PowerSystem::make(
+    ambient_power_drain);
+  if (!ambient_power_system)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for ambient power system");
+
+    return nullptr;
+  }
+  std::shared_ptr<rmf_battery::agv::SimpleDevicePowerSink> ambient_sink =
+    std::make_shared<rmf_battery::agv::SimpleDevicePowerSink>(
+    *battery_system, *ambient_power_system);
+
+  // Tool power system
+  const double tool_power_drain = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "tool_power_drain", 10.0);
+  auto tool_power_system = rmf_battery::agv::PowerSystem::make(
+    tool_power_drain);
+  if (!tool_power_system)
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Invalid values supplied for tool power system");
+
+    return nullptr;
+  }
+  std::shared_ptr<rmf_battery::agv::SimpleDevicePowerSink> tool_sink =
+    std::make_shared<rmf_battery::agv::SimpleDevicePowerSink>(
+    *battery_system, *tool_power_system);
+
+  // Drain battery
+  const bool drain_battery = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "drain_battery", false);
+  // Recharge threshold
+  const double recharge_threshold = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "recharge_threshold", 0.2);
+  // Recharge state of charge
+  const double recharge_soc = rmf_fleet_adapter::get_parameter_or_default(
+    *node, "recharge_soc", 1.0);
+  const std::string finishing_request_string =
+    node->declare_parameter("finishing_request", "nothing");
+  rmf_task::ConstRequestFactoryPtr finishing_request = nullptr;
+  if (finishing_request_string == "charge")
+  {
+    finishing_request =
+      std::make_shared<rmf_task::requests::ChargeBatteryFactory>();
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Fleet is configured to perform ChargeBattery as finishing request");
+  }
+  else if (finishing_request_string == "park")
+  {
+    finishing_request =
+      std::make_shared<rmf_task::requests::ParkRobotFactory>();
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Fleet is configured to perform ParkRobot as finishing request");
+  }
+  else if (finishing_request_string == "nothing")
+  {
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Fleet is not configured to perform any finishing request");
+  }
+  else
+  {
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Provided finishing request [%s] is unsupported. The valid "
+      "finishing requests are [charge, park, nothing]. The task planner will "
+      " default to [nothing].",
+      finishing_request_string.c_str());
+  }
+
+  if (!connections->fleet->set_task_planner_params(
+      battery_system,
+      motion_sink,
+      ambient_sink,
+      tool_sink,
+      recharge_threshold,
+      recharge_soc,
+      drain_battery,
+      finishing_request))
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Failed to initialize task planner parameters");
+
+    return nullptr;
+  }
+
+  std::unordered_set<uint8_t> task_types;
+  if (node->declare_parameter<bool>("perform_loop", false))
+  {
+    task_types.insert(rmf_task_msgs::msg::TaskType::TYPE_LOOP);
+  }
+
+  // If the perform_deliveries parameter is true, then we just blindly accept
+  // all delivery requests.
+  if (node->declare_parameter<bool>("perform_deliveries", false))
+  {
+    task_types.insert(rmf_task_msgs::msg::TaskType::TYPE_DELIVERY);
+    connections->fleet->accept_delivery_requests(
+      [](const rmf_task_msgs::msg::Delivery&) { return true; });
+  }
+
+  if (node->declare_parameter<bool>("perform_cleaning", false))
+  {
+    task_types.insert(rmf_task_msgs::msg::TaskType::TYPE_CLEAN);
+  }
+
+  connections->fleet->accept_task_requests(
+    [task_types](const rmf_task_msgs::msg::TaskProfile& msg)
+    {
+      if (task_types.find(msg.description.task_type.type) != task_types.end())
+        return true;
+
+      return false;
+    });
+
+  if (node->declare_parameter<bool>("disable_delay_threshold", false))
+  {
+    connections->fleet->default_maximum_delay(rmf_utils::nullopt);
+  }
+  else
+  {
+    connections->fleet->default_maximum_delay(
+      rmf_fleet_adapter::get_parameter_or_default_time(
+        *node, "delay_threshold", 10.0));
+  }
+
+  connections->path_request_pub = node->create_publisher<
+    rmf_fleet_msgs::msg::PathRequest>(
+    rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS());
+
+  connections->mode_request_pub = node->create_publisher<
+    rmf_fleet_msgs::msg::ModeRequest>(
+    rmf_fleet_adapter::ModeRequestTopicName, rclcpp::SystemDefaultsQoS());
+
+  connections->fleet_state_sub = node->create_subscription<
+    rmf_fleet_msgs::msg::FleetState>(
+    rmf_fleet_adapter::FleetStateTopicName,
+    rclcpp::SystemDefaultsQoS(),
+    [c = std::weak_ptr<Connections>(connections), fleet_name](
+      const rmf_fleet_msgs::msg::FleetState::SharedPtr msg)
+    {
+      if (msg->name != fleet_name)
+        return;
+
+      const auto connections = c.lock();
+      if (!connections)
+        return;
+
+      for (const auto& state : msg->robots)
+      {
+        const auto insertion = connections->robots.insert({state.name,
+          nullptr});
+        const bool new_robot = insertion.second;
+        if (new_robot)
+        {
+          // We have not seen this robot before, so let's add it to the fleet.
+          connections->add_robot(fleet_name, state);
+        }
+
+        const auto& command = insertion.first->second;
+        if (command)
+        {
+          // We are ready to command this robot, so let's update its state
+          command->update_state(state);
+        }
+      }
+    });
+
+  const std::string lift_clearance_srv =
+    node->declare_parameter<std::string>(
+    "experimental_lift_watchdog_service", "");
+  if (!lift_clearance_srv.empty())
+  {
+    connections->lift_watchdog_client =
+      node->create_client<rmf_fleet_msgs::srv::LiftClearance>(
+      lift_clearance_srv);
+  }
+
+  connections->manager = make_manager(fleet_name, connections->graph);
+
+  return connections;
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  const auto node = std::make_shared<rclcpp::Node>("manager_test_node");
+  // const auto adapter = rmf_fleet_adapter::agv::Adapter::make("fleet_adapter");
+  // if (!adapter)
+  //   return 1;
+
+  // const auto fleet_connections = make_fleet(adapter);
+  // if (!fleet_connections)
+  //   return 1;
+
+  // RCLCPP_INFO(adapter->node()->get_logger(), "Starting Fleet Adapter");
+
+  // Start running the adapter and wait until it gets stopped by SIGINT
+  // adapter->start().wait();
+
+  // RCLCPP_INFO(adapter->node()->get_logger(), "Closing Fleet Adapter");
+
+  const std::string fleet_name = "tinyRobot";
+  const std::string robot_name = "tinyRobot1";
+  const std::string robot_model = "tinyRobot";
+
+  const std::string test_map_name = "test_level";
+  std::shared_ptr<rmf_traffic::agv::Graph> graph(new rmf_traffic::agv::Graph);
+  graph->add_waypoint(test_map_name, {0, 0});
+  graph->add_waypoint(test_map_name, {10, 0});
+  graph->add_waypoint(test_map_name, {-10, 0});
+  graph->add_waypoint(test_map_name, {0, 10});
+  graph->add_waypoint(test_map_name, {0, -10});
+  graph->add_lane(0, 1);
+  graph->add_lane(1, 0);
+  graph->add_lane(0, 2);
+  graph->add_lane(2, 0);
+  graph->add_lane(0, 3);
+  graph->add_lane(3, 0);
+  graph->add_lane(0, 4);
+  graph->add_lane(4, 0);
+
+  std::unique_ptr<free_fleet::transport::ServerMiddleware> m =
+    free_fleet::cyclonedds::ServerDDSMiddleware::make_unique(0, fleet_name); // to do: dds domain as param
+  auto ct = free_fleet::manager::SimpleCoordinateTransformer::make(
+    1.0,
+    0.0,
+    0.0,
+    0.0);
+  free_fleet::Manager::TimeNow time_now_fn =
+    []() { return std::chrono::steady_clock::now(); };
+  free_fleet::Manager::RobotUpdatedCallback cb =
+    [](const free_fleet::manager::RobotInfo& updated_robot_info)
+    {
+      std::cout << updated_robot_info.name() << " updated state\n";
+    };
+
+  auto manager = free_fleet::Manager::make(
+    fleet_name,
+    graph,
+    std::move(m),
+    ct,
+    time_now_fn,
+    cb);
+
+  dds_sleepfor(DDS_MSECS(5000));
+  using NavigationPoint = free_fleet::Manager::NavigationPoint;
+  auto id = manager->request_navigation(
+    robot_name,
+    {
+      NavigationPoint{0, 0.0},
+      NavigationPoint{1, 0.0}
+    });
+  std::cout << "Manager requested navigation with command id" <<
+  (uint32_t) (id.value()) << std::endl;
+
+  dds_sleepfor(DDS_MSECS(5000));
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+
+}

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.7.0)
+project(free_fleet_ros2_client)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_BUILD_TYPE Debug)
+
+find_package(ament_cmake REQUIRED)
+include(GNUInstallDirs)
+
+set(dep_pkgs
+  rclcpp
+  rmf_fleet_msgs
+  rmf_task_msgs
+  rmf_traffic
+  rmf_traffic_ros2
+  rmf_fleet_adapter
+  free_fleet
+  free_fleet_cyclonedds
+  CycloneDDS
+)
+foreach(pkg ${dep_pkgs})
+  find_package(${pkg} REQUIRED)
+endforeach()
+
+# -----------------------------------------------------------------------------
+add_executable(client 
+  src/main.cpp
+  src/SlotcarCommandHandle.cpp
+  src/SlotcarStatusHandle.cpp
+)
+
+target_link_libraries(client
+  PRIVATE
+    free_fleet::free_fleet
+    free_fleet_cyclonedds::free_fleet_cyclonedds
+    rmf_fleet_adapter::rmf_fleet_adapter
+    ${rclcpp_LIBRARIES}
+    ${rmf_fleet_msgs_LIBRARIES}
+    ${rmf_task_msgs_LIBRARIES}
+    CycloneDDS::ddsc
+)
+target_include_directories(client
+  PRIVATE
+   ${rmf_fleet_msgs_INCLUDE_DIRS}
+    ${rmf_task_msgs_INCLUDE_DIRS}
+)
+
+install(TARGETS
+  client
+  DESTINATION lib/${PROJECT_NAME}
+)
+ament_package()

--- a/client/package.xml
+++ b/client/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>free_fleet_ros2_client</name>
+  <version>1.1.0</version>
+  <description>Free fleet ROS 2 implementations</description>
+  <maintainer email="aaron@openrobotics.org">Aaron</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>rmf_utils</depend>
+  <depend>rmf_traffic</depend>
+  <depend>rmf_traffic_ros2</depend>
+  <depend>rmf_fleet_adapter</depend>
+
+  <depend>free_fleet</depend>
+  <depend>free_fleet_cyclonedds</depend>
+
+  <build_depend>eigen</build_depend>
+
+  <test_depend>ament_cmake_catch2</test_depend>
+  <test_depend>rmf_cmake_uncrustify</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/client/src/SlotcarCommandHandle.cpp
+++ b/client/src/SlotcarCommandHandle.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+// ROS2 utilities for rmf_traffic
+#include <rmf_traffic_ros2/Time.hpp>
+
+#include <rmf_fleet_adapter/StandardNames.hpp>
+
+#include "SlotcarCommandHandle.hpp"
+
+SlotcarCommandHandle::SlotcarCommandHandle(
+  rclcpp::Node& node,
+  std::string fleet_name,
+  std::string robot_name,
+  PathRequestPub path_request_pub,
+  ModeRequestPub mode_request_pub)
+: _node(&node),
+  _path_request_pub(path_request_pub),
+  _mode_request_pub(mode_request_pub),
+  _location("None", {0.0, 0.0}, 0.0),
+  _mode(free_fleet::messages::RobotMode::Mode::Idle),
+  _battery_percent(1.0)
+{
+
+  std::function<void(std::shared_ptr<rmf_fleet_msgs::msg::FleetState>)> fn =
+    std::bind(
+    &SlotcarCommandHandle::fleet_state_cb, this, std::placeholders::_1,
+    fleet_name,
+    robot_name);
+
+  _fleet_state_sub = _node->create_subscription<
+    rmf_fleet_msgs::msg::FleetState>(
+    rmf_fleet_adapter::FleetStateTopicName,
+    rclcpp::SystemDefaultsQoS(),
+    fn
+    );
+
+  _current_path_request.fleet_name = fleet_name;
+  _current_path_request.robot_name = robot_name;
+
+  _current_dock_request.fleet_name = fleet_name;
+  _current_dock_request.robot_name = robot_name;
+  _current_dock_request.mode.mode = _current_dock_request.mode.MODE_DOCKING;
+
+  rmf_fleet_msgs::msg::ModeParameter p;
+  p.name = "docking";
+  _current_dock_request.parameters.push_back(std::move(p));
+
+}
+
+void SlotcarCommandHandle::relocalize(
+  const free_fleet::messages::Location& location,
+  RequestCompleted relocalization_finished_callback)
+{
+  RCLCPP_WARN(
+    _node->get_logger(),
+    "Relocalize is not supported.");
+  relocalization_finished_callback();
+  return;
+}
+
+void SlotcarCommandHandle::follow_new_path(
+  const std::vector<free_fleet::messages::Waypoint>& waypoints,
+  RequestCompleted path_finished_callback)
+{
+  auto lock = _lock();
+  _clear_last_command();
+
+  _path_finished_callback = std::move(path_finished_callback);
+  _target_path_waypoint_index = 0;
+  _current_path_request.task_id = std::to_string(++_current_task_id);
+  _current_path_request.path.clear();
+
+  for (const auto& wp : waypoints)
+  {
+    rmf_fleet_msgs::msg::Location location;
+
+    const Eigen::Vector2d p = wp.location().coordinates();
+    if (wp.wait_until())
+      location.t = rmf_traffic_ros2::convert(*(wp.wait_until()));
+
+    location.x = p.x();
+    location.y = p.y();
+    location.yaw = (float) wp.location().yaw().value_or(0);
+
+    _current_path_request.path.emplace_back(std::move(location));
+  }
+
+  _path_requested_time = std::chrono::steady_clock::now();
+  _path_request_pub->publish(_current_path_request);
+}
+
+void SlotcarCommandHandle::stop(RequestCompleted stopped_callback)
+{
+  return;
+}
+
+void SlotcarCommandHandle::resume(RequestCompleted resumed_callback)
+{
+  return;
+}
+
+bool SlotcarCommandHandle::dock(
+  const std::string& dock_name,
+  RequestCompleted docking_finished_callback)
+{
+  auto lock = _lock();
+  _clear_last_command();
+
+  _dock_finished_callback = std::move(docking_finished_callback);
+  _current_dock_request.parameters.front().value = dock_name;
+  _current_dock_request.task_id = std::to_string(++_current_task_id);
+
+  _dock_requested_time = std::chrono::steady_clock::now();
+  _mode_request_pub->publish(_current_dock_request);
+
+  // Didn't log _dock_target_wp
+  RCLCPP_INFO(
+    _node->get_logger(),
+    "Requesting robot [%s] of [%s] to dock",
+    _current_path_request.robot_name.c_str(),
+    _current_path_request.fleet_name.c_str()
+  );
+
+  return true;
+}
+
+void SlotcarCommandHandle::fleet_state_cb(
+  const rmf_fleet_msgs::msg::FleetState::SharedPtr msg,
+  const std::string fleet_name,
+  const std::string robot_name)
+{
+  if (msg->name != fleet_name)
+  {
+    return;
+  }
+  for (const auto& state : msg->robots)
+  {
+    if (state.name == robot_name)
+    {
+      _location = free_fleet::messages::Location(
+        state.location.level_name,
+        {state.location.x, state.location.y},
+        state.location.yaw);
+
+      auto rm = free_fleet::messages::RobotMode::Mode::Undefined;
+      std::string info;
+
+      switch (state.mode.mode)
+      {
+        case rmf_fleet_msgs::msg::RobotMode::MODE_IDLE:
+          rm = free_fleet::messages::RobotMode::Mode::Idle;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_CHARGING:
+          rm = free_fleet::messages::RobotMode::Mode::Charging;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_MOVING:
+          rm = free_fleet::messages::RobotMode::Mode::Moving;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_PAUSED:
+          rm = free_fleet::messages::RobotMode::Mode::Paused;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_EMERGENCY:
+          rm = free_fleet::messages::RobotMode::Mode::Emergency;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_GOING_HOME:
+          rm = free_fleet::messages::RobotMode::Mode::Custom;
+          info = "MODE_GOING_HOME";
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_DOCKING:
+          rm = free_fleet::messages::RobotMode::Mode::Docking;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_ADAPTER_ERROR:
+          rm = free_fleet::messages::RobotMode::Mode::Error;
+          break;
+        case rmf_fleet_msgs::msg::RobotMode::MODE_CLEANING:
+          rm = free_fleet::messages::RobotMode::Mode::Custom;
+          info = "MODE_CLEANING";
+          break;
+      }
+
+      _mode = free_fleet::messages::RobotMode(rm, info);
+
+      _battery_percent = state.battery_percent / 100;
+
+      if (_path_finished_callback)
+      {
+        // If we have a path_finished_callback, then the robot should be
+        // following a path
+        _target_path_waypoint_index = _current_path_request.path.size() -
+          state.path.size();
+
+        // There should not be a docking command happening
+        assert(!_dock_finished_callback);
+
+        if (state.task_id != _current_path_request.task_id)
+        {
+          // The robot has not received our path request yet
+          const auto now = std::chrono::steady_clock::now();
+          if (std::chrono::milliseconds(200) < now - _path_requested_time)
+          {
+            // We published the request a while ago, so we'll send it again in
+            // case it got dropped.
+            _path_requested_time = now;
+            _path_request_pub->publish(_current_path_request);
+          }
+          return;
+        }
+        if (state.path.empty())
+        {
+          // When the state path is empty, that means the robot believes it has
+          // arrived at its destination.
+          RCLCPP_INFO(
+            _node->get_logger(),
+            "%s has completed its path",
+            robot_name.c_str());
+          assert(_path_finished_callback);
+          _path_finished_callback();
+          _target_path_waypoint_index = std::nullopt;
+          _path_finished_callback = nullptr;
+        }
+
+      }
+      else if (_dock_finished_callback)
+      {
+        const auto now = std::chrono::steady_clock::now();
+        // If we have a _dock_finished_callback, then the robot should be docking
+        if (state.task_id != _current_dock_request.task_id)
+        {
+          if (std::chrono::milliseconds(200) < now - _dock_requested_time)
+          {
+            // We published the request a while ago, so we'll send it again in
+            // case it got dropped.
+            _dock_requested_time = now;
+            _mode_request_pub->publish(_current_dock_request);
+          }
+
+          return;
+        }
+
+        if (state.mode.mode != state.mode.MODE_DOCKING)
+        {
+          RCLCPP_INFO(
+            _node->get_logger(),
+            "%s has completed docking",
+            robot_name.c_str());
+          _dock_finished_callback();
+          _dock_finished_callback = nullptr;
+
+          return;
+        }
+      }
+    }
+  }
+}
+
+free_fleet::messages::Location SlotcarCommandHandle::location() const
+{
+  return _location;
+}
+
+free_fleet::messages::RobotMode SlotcarCommandHandle::mode() const
+{
+  return _mode;
+}
+
+double SlotcarCommandHandle::battery_percent() const
+{
+  return _battery_percent;
+}
+
+std::optional<std::size_t> SlotcarCommandHandle::target_path_waypoint_index()
+const
+{
+  return _target_path_waypoint_index;
+}
+
+void SlotcarCommandHandle::_clear_last_command()
+{
+  _path_finished_callback = nullptr;
+  _dock_finished_callback = nullptr;
+}

--- a/client/src/SlotcarCommandHandle.hpp
+++ b/client/src/SlotcarCommandHandle.hpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef INCLUDE__FREE_FLEET_ROS2__CLIENT__SLOTCARCOMMANDHANDLE__HPP
+#define INCLUDE__FREE_FLEET_ROS2__CLIENT__SLOTCARCOMMANDHANDLE__HPP
+
+#include <rclcpp/rclcpp.hpp>
+
+// Fleet driver state/command messages
+#include <rmf_fleet_msgs/msg/fleet_state.hpp>
+#include <rmf_fleet_msgs/msg/path_request.hpp>
+#include <rmf_fleet_msgs/msg/mode_request.hpp>
+// #include <rmf_fleet_msgs/srv/lift_clearance.hpp>
+// #include <rmf_fleet_msgs/msg/lane_request.hpp>
+// #include <rmf_fleet_msgs/msg/closed_lanes.hpp>
+
+#include <rmf_traffic/Time.hpp>
+
+#include <free_fleet/client/CommandHandle.hpp>
+#include <free_fleet/messages/Location.hpp>
+#include <free_fleet/messages/Waypoint.hpp>
+#include <free_fleet/messages/RobotMode.hpp>
+
+class SlotcarCommandHandle
+  : public free_fleet::client::CommandHandle
+{
+public:
+
+  using PathRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::PathRequest>::SharedPtr;
+
+  using ModeRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr;
+
+  SlotcarCommandHandle(
+    rclcpp::Node& node,
+    std::string fleet_name,
+    std::string robot_name,
+    PathRequestPub path_request_pub,
+    ModeRequestPub mode_request_pub
+  );
+
+  void relocalize(
+    const free_fleet::messages::Location& location,
+    RequestCompleted relocalization_finished_callback) override;
+
+  void follow_new_path(
+    const std::vector<free_fleet::messages::Waypoint>& waypoints,
+    RequestCompleted path_finished_callback) override;
+
+  void stop(RequestCompleted stopped_callback) override;
+
+  void resume(RequestCompleted resumed_callback) override;
+
+  bool dock(
+    const std::string& dock_name,
+    RequestCompleted docking_finished_callback) override;
+
+  free_fleet::messages::Location location() const;
+
+  free_fleet::messages::RobotMode mode() const;
+  double battery_percent() const;
+
+  std::optional<std::size_t> target_path_waypoint_index()
+  const;
+
+  free_fleet::messages::Location location();
+  free_fleet::messages::RobotMode robot_mode();
+  double battery_percent();
+  std::optional<std::size_t> target_path_waypoint_index();
+
+private:
+
+  rclcpp::Node* _node;
+
+  PathRequestPub _path_request_pub;
+  rmf_fleet_msgs::msg::PathRequest _current_path_request;
+  std::chrono::steady_clock::time_point _path_requested_time;
+
+  rmf_fleet_msgs::msg::ModeRequest _current_dock_request;
+  std::chrono::steady_clock::time_point _dock_requested_time;
+  RequestCompleted _path_finished_callback;
+  RequestCompleted _dock_finished_callback;
+  ModeRequestPub _mode_request_pub;
+
+  rclcpp::Subscription<rmf_fleet_msgs::msg::FleetState>::SharedPtr
+    _fleet_state_sub;
+
+  uint32_t _current_task_id = 0;
+
+  std::mutex _mutex;
+
+  std::unique_lock<std::mutex> _lock()
+  {
+    std::unique_lock<std::mutex> lock(_mutex, std::defer_lock);
+    while (!lock.try_lock())
+    {
+      // Intentionally busy wait
+    }
+
+    return lock;
+  }
+
+  void fleet_state_cb(
+    const rmf_fleet_msgs::msg::FleetState::SharedPtr msg,
+    const std::string fleet_name,
+    const std::string robot_name);
+
+  void _clear_last_command();
+
+  // Robot status
+  free_fleet::messages::Location _location;
+  free_fleet::messages::RobotMode _mode;
+  double _battery_percent;
+  std::optional<std::size_t> _target_path_waypoint_index;
+
+};
+
+#endif // INCLUDE__FREE_FLEET_ROS2__CLIENT__SLOTCARCOMMANDHANDLE__HPP

--- a/client/src/SlotcarStatusHandle.cpp
+++ b/client/src/SlotcarStatusHandle.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "SlotcarStatusHandle.hpp"
+
+SlotcarStatusHandle::SlotcarStatusHandle(
+  const SlotcarCommandHandle& command_handle
+)
+: _command_handle(command_handle)
+{
+}
+
+rmf_traffic::Time SlotcarStatusHandle::time() const
+{
+  return std::chrono::steady_clock::now();
+}
+
+free_fleet::messages::Location SlotcarStatusHandle::location() const
+{
+  return _command_handle.location();
+}
+
+free_fleet::messages::RobotMode SlotcarStatusHandle::mode() const
+{
+  return _command_handle.mode();
+}
+
+double SlotcarStatusHandle::battery_percent() const
+{
+  return _command_handle.battery_percent();
+}
+
+std::optional<std::size_t> SlotcarStatusHandle::target_path_waypoint_index()
+const
+{
+  return _command_handle.target_path_waypoint_index();
+}

--- a/client/src/SlotcarStatusHandle.hpp
+++ b/client/src/SlotcarStatusHandle.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef INCLUDE__FREE_FLEET_ROS2__CLIENT__SLOTCARSTATUSHANDLE__HPP
+#define INCLUDE__FREE_FLEET_ROS2__CLIENT__SLOTCARSTATUSHANDLE__HPP
+
+#include <free_fleet/client/StatusHandle.hpp>
+
+#include "SlotcarCommandHandle.hpp"
+
+class SlotcarStatusHandle : public free_fleet::client::StatusHandle
+{
+public:
+
+  SlotcarStatusHandle(
+    const SlotcarCommandHandle& command_handle
+  );
+
+  rmf_traffic::Time time() const;
+
+  free_fleet::messages::Location location() const override final;
+
+  free_fleet::messages::RobotMode mode() const override final;
+
+  double battery_percent() const override final;
+
+  std::optional<std::size_t> target_path_waypoint_index() const override final;
+
+private:
+
+  const SlotcarCommandHandle& _command_handle;
+
+};
+
+#endif // INCLUDE__FREE_FLEET_ROS2__CLIENT__SLOTCARSTATUSHANDLE__HPP

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,0 +1,103 @@
+#include <free_fleet/client/Client.hpp>
+#include <free_fleet/Executor.hpp>
+#include <free_fleet/Worker.hpp>
+#include <free_fleet_cyclonedds/ClientDDSMiddleware.hpp>
+
+#include "SlotcarCommandHandle.hpp"
+#include "SlotcarStatusHandle.hpp"
+
+int main(int argc, char** argv)
+{
+
+  rclcpp::init(argc, argv);
+  using PathRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::PathRequest>::SharedPtr;
+  using ModeRequestPub =
+    rclcpp::Publisher<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr;
+  const auto node = std::make_shared<rclcpp::Node>("free_fleet_client");
+
+  const std::string fleet_name_param_name = "fleet_name";
+  const std::string fleet_name = node->declare_parameter(
+    fleet_name_param_name, std::string());
+  if (fleet_name.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", fleet_name_param_name.c_str());
+
+    return 1;
+  }
+
+  const std::string robot_name_param_name = "robot_name";
+  const std::string robot_name = node->declare_parameter(
+    robot_name_param_name, std::string());
+  if (robot_name.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", robot_name_param_name.c_str());
+
+    return 1;
+  }
+
+  const std::string robot_model_param_name = "robot_model";
+  const std::string robot_model = node->declare_parameter(
+    robot_model_param_name, std::string());
+  if (robot_model.empty())
+  {
+    RCLCPP_ERROR(
+      node->get_logger(),
+      "Missing [%s] parameter", robot_model_param_name.c_str());
+
+    return 1;
+  }
+
+  const std::string dds_domain_param_name = "dds_domain";
+  node->declare_parameter(dds_domain_param_name);
+  const int dds_domain = node->get_parameter(dds_domain_param_name).as_int();
+
+  PathRequestPub path_request_pub = node->create_publisher<
+    rmf_fleet_msgs::msg::PathRequest>(
+    "robot_path_requests", rclcpp::SystemDefaultsQoS());
+
+  ModeRequestPub mode_request_pub = node->create_publisher<
+    rmf_fleet_msgs::msg::ModeRequest>(
+    "robot_mode_requests", rclcpp::SystemDefaultsQoS());
+
+  auto command_handle = std::make_shared<SlotcarCommandHandle>(
+    *node,
+    fleet_name,
+    robot_name,
+    path_request_pub,
+    mode_request_pub);
+
+  auto status_handle = std::make_shared<SlotcarStatusHandle>(
+    *command_handle
+  );
+
+  auto middleware = free_fleet::cyclonedds::ClientDDSMiddleware::make_unique(
+    dds_domain,
+    fleet_name);
+
+  auto client = free_fleet::Client::make(
+    robot_name,
+    robot_model,
+    command_handle,
+    status_handle,
+    std::move(middleware)
+  );
+
+  free_fleet::Executor executor(
+    (std::unique_ptr<free_fleet::Worker>)client.get());
+
+  RCLCPP_INFO(
+    node->get_logger(),
+    "Starting free fleet client for %s",
+    robot_name.c_str());
+  executor.start_async(std::chrono::nanoseconds((int)1e9));
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(free_fleet_ros2_examples)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY
+  launch/
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/examples/launch/hotel_clients.launch.xml
+++ b/examples/launch/hotel_clients.launch.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' ?>
+
+<launch>
+
+  <node pkg="free_fleet_ros2_client"
+        exec="client"
+        name="ffr2_client_deliveryBot_1" 
+        output="both">
+
+    <param name="fleet_name" value="deliveryBot"/>
+    <param name="robot_model" value="slotcar_deliveryBot"/>
+    <param name="robot_name" value="deliveryBot_1"/>
+    <param name="dds_domain" value="0"/>
+  </node>
+  <node pkg="free_fleet_ros2_client"
+        exec="client"
+        name="ffr2_client_tinyBot1" 
+        output="both">
+
+    <param name="fleet_name" value="tinyBot"/>
+    <param name="robot_model" value="tinyBot"/>
+    <param name="robot_name" value="tinyBot_1"/>
+    <param name="dds_domain" value="0"/>
+  </node>
+  <node pkg="free_fleet_ros2_client"
+        exec="client"
+        name="ffr2_client_cleanerBotA_1" 
+        output="both">
+
+    <param name="fleet_name" value="cleanerBotA"/>
+    <param name="robot_model" value="cleanerBotA"/>
+    <param name="robot_name" value="cleanerBotA_1"/>
+    <param name="dds_domain" value="0"/>
+  </node>
+  <node pkg="free_fleet_ros2_client"
+        exec="client"
+        name="ffr2_client_cleanerBotA_2" 
+        output="both">
+
+    <param name="fleet_name" value="cleanerBotA"/>
+    <param name="robot_model" value="cleanerBotA"/>
+    <param name="robot_name" value="cleanerBotA_2"/>
+    <param name="dds_domain" value="0"/>
+  </node>
+
+</launch>

--- a/examples/launch/office_clients.launch.xml
+++ b/examples/launch/office_clients.launch.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' ?>
+
+<launch>
+
+  <node pkg="free_fleet_ros2_client"
+        exec="client"
+        name="ffr2_client_tinyRobot1" 
+        output="both">
+
+    <param name="fleet_name" value="tinyRobot"/>
+    <param name="robot_model" value="tinyRobot"/>
+    <param name="robot_name" value="tinyRobot1"/>
+    <param name="dds_domain" value="0"/>
+  </node>
+
+  <node pkg="free_fleet_ros2_client"
+        exec="client"
+        name="ffr2_client_tinyRobot2" 
+        output="both">
+
+    <param name="fleet_name" value="tinyRobot"/>
+    <param name="robot_model" value="tinyRobot"/>
+    <param name="robot_name" value="tinyRobot2"/>
+    <param name="dds_domain" value="0"/>
+  </node>
+
+</launch>

--- a/examples/package.xml
+++ b/examples/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>free_fleet_ros2_examples</name>
+  <version>1.1.0</version>
+  <description>Free Fleet ROS 2 examples</description>
+  <maintainer email="aaron@openrobotics.org">Aaron</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+ 
+  <exec_depend>free_fleet_ros2_adapter</exec_depend>
+  <exec_depend>free_fleet_ros2_client</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Implementation of a fleet adapter that integrates [`free_fleet`](https://github.com/open-rmf/free_fleet/pull/76) manager and clients with the RMF demos (`rmf_demos` commit 2371649),

The `adapter` is based on the existing full_control fleet adapter, with modifications to utilise `free_fleet`'s features for control and tracking of robots.

`client` provides an implementation of `free_fleet`'s client for the slotcar robot from `rmf_simulation.`